### PR TITLE
Refactor math functions and constants for consistency and clarity

### DIFF
--- a/src/war_actions.c
+++ b/src/war_actions.c
@@ -1164,18 +1164,18 @@ void wact_updateAction(WarContext* context, WarEntity* entity)
                     // super complicated math here:
                     //
                     // d               d
-                    // N:  4 - abs(4 - 0) = 4 - 4 = 0
-                    // NE: 4 - abs(4 - 1) = 4 - 3 = 1
-                    // E:  4 - abs(4 - 2) = 4 - 2 = 2
-                    // SW: 4 - abs(4 - 3) = 4 - 1 = 3
-                    // S:  4 - abs(4 - 4) = 4 - 0 = 4
-                    // SW: 4 - abs(4 - 5) = 4 - 1 = 3
-                    // W:  4 - abs(4 - 6) = 4 - 2 = 2
-                    // NW: 4 - abs(4 - 7) = 4 - 3 = 1
+                    // N:  4 - ABS(4 - 0) = 4 - 4 = 0
+                    // NE: 4 - ABS(4 - 1) = 4 - 3 = 1
+                    // E:  4 - ABS(4 - 2) = 4 - 2 = 2
+                    // SW: 4 - ABS(4 - 3) = 4 - 1 = 3
+                    // S:  4 - ABS(4 - 4) = 4 - 0 = 4
+                    // SW: 4 - ABS(4 - 5) = 4 - 1 = 3
+                    // W:  4 - ABS(4 - 6) = 4 - 2 = 2
+                    // NW: 4 - ABS(4 - 7) = 4 - 3 = 1
                     //
-                    // ... 4 - abs(4 - d)
+                    // ... 4 - ABS(4 - d)
 
-                    frameIndex += (4 - abs(4 - (s32)unit->direction));
+                    frameIndex += (4 - ABS(4 - (s32)unit->direction));
 
                     transform->scale.x = inRange(unit->direction, WAR_DIRECTION_SOUTH_WEST, WAR_DIRECTION_COUNT) ? -1.0f : 1.0f;
                 }

--- a/src/war_animations.c
+++ b/src/war_animations.c
@@ -2,6 +2,7 @@
 
 #include "war_animations.h"
 #include "war_sprites.h"
+#include "war_resources.h"
 
 #define ANIM_NAME_MAX_LENGTH 50
 
@@ -229,7 +230,7 @@ WarSpriteAnimation* wanim_createDamageAnimation(WarContext* context, WarEntity* 
     WarSpriteResourceRef spriteResourceRef = imageResourceRef(resourceIndex);
     WarSprite sprite = wspr_createSpriteFromResourceIndex(context, spriteResourceRef);
     WarSpriteAnimation* anim = wanim_createAnimation(context, name, sprite, 0.2f, true);
-    anim->offset = vec2Subv(wu_getUnitSpriteCenter(entity), vec2i(halfi(sprite.frameWidth), sprite.frameHeight));
+    anim->offset = vec2_subv(wu_getUnitSpriteCenter(entity), vec2i(sprite.frameWidth/2, sprite.frameHeight));
 
     for(s32 i = 0; i < 4; i++)
         wanim_addAnimationFrame(anim, i);
@@ -255,8 +256,8 @@ WarSpriteAnimation* wanim_createCollapseAnimation(WarContext* context, WarEntity
 
     // if the offset is based on the size of the frame, and it's scaled, then the offset must take into
     // account the scale to make the calculations
-    f32 offsetx = halff(unitFrameSize.x - unitSpriteSize.x);
-    f32 offsety = halff(unitFrameSize.y - unitSpriteSize.y) - (animFrameSize.y * animScale - unitSpriteSize.y);
+    f32 offsetx = 0.5f * (unitFrameSize.x - unitSpriteSize.x);
+    f32 offsety = 0.5f * (unitFrameSize.y - unitSpriteSize.y) - (animFrameSize.y * animScale - unitSpriteSize.y);
 
     anim->scale = vec2f(animScale, animScale);
     anim->offset = vec2f(offsetx, offsety);
@@ -278,8 +279,8 @@ WarSpriteAnimation* wanim_createExplosionAnimation(WarContext* context, WarEntit
     wstr_appendFormat(&name, "explosion_%.2f_%.2f", position.x, position.y);
     WarSpriteAnimation* anim = wanim_createAnimation(context, name, sprite, 0.1f, false);
 
-    f32 offsetx = position.x - halff(sprite.frameWidth);
-    f32 offsety = position.y - halff(sprite.frameHeight);
+    f32 offsetx = position.x - 0.5f * sprite.frameWidth;
+    f32 offsety = position.y - 0.5f * sprite.frameHeight;
     anim->offset = vec2f(offsetx, offsety);
 
     for(s32 i = 0; i < 6; i++)
@@ -299,8 +300,8 @@ WarSpriteAnimation* wanim_createRainOfFireExplosionAnimation(WarContext* context
     wstr_appendFormat(&name, "explosion_%.2f_%.2f", position.x, position.y);
     WarSpriteAnimation* anim = wanim_createAnimation(context, name, sprite, 0.1f, false);
 
-    f32 offsetx = position.x - halff(sprite.frameWidth);
-    f32 offsety = position.y - halff(sprite.frameHeight);
+    f32 offsetx = position.x - 0.5f * sprite.frameWidth;
+    f32 offsety = position.y - 0.5f * sprite.frameHeight;
     anim->offset = vec2f(offsetx, offsety);
 
     for(s32 i = 3; i < 6; i++)
@@ -320,8 +321,8 @@ WarSpriteAnimation* wanim_createSpellAnimation(WarContext* context, WarEntity* e
     wstr_appendFormat(&name, "spell_%.2f_%.2f", position.x, position.y);
     WarSpriteAnimation* anim = wanim_createAnimation(context, name, sprite, 0.4f, false);
 
-    f32 offsetx = position.x - halff(sprite.frameWidth);
-    f32 offsety = position.y - halff(sprite.frameHeight);
+    f32 offsetx = position.x - 0.5f * sprite.frameWidth;
+    f32 offsety = position.y - 0.5f * sprite.frameHeight;
     anim->offset = vec2f(offsetx, offsety);
 
     for(s32 i = 0; i < 6; i++)
@@ -341,8 +342,8 @@ WarSpriteAnimation* wanim_createPoisonCloudAnimation(WarContext* context, WarEnt
     wstr_appendFormat(&name, "poison_cloud_%.2f_%.2f", position.x, position.y);
     WarSpriteAnimation* anim = wanim_createAnimation(context, name, sprite, 0.5f, true);
 
-    f32 offsetx = position.x - halff(sprite.frameWidth);
-    f32 offsety = position.y - halff(sprite.frameHeight);
+    f32 offsetx = position.x - 0.5f * sprite.frameWidth;
+    f32 offsety = position.y - 0.5f * sprite.frameHeight;
     anim->offset = vec2f(offsetx, offsety);
 
     for(s32 i = 0; i < 4; i++)

--- a/src/war_audio.c
+++ b/src/war_audio.c
@@ -196,7 +196,7 @@ bool wa_playMidi(WarContext* context, WarEntity* entity, u32 sampleCount, s16* o
     while (sampleCount)
     {
         //We progress the MIDI playback and then process TSF_RENDER_EFFECTSAMPLEBLOCK samples at once
-        u32 sampleBlock = min(TSF_RENDER_EFFECTSAMPLEBLOCK, sampleCount);
+        u32 sampleBlock = MIN(TSF_RENDER_EFFECTSAMPLEBLOCK, sampleCount);
         audio->playbackTime += sampleBlock * (1000.0f / PLAYBACK_FREQ);
 
         //Loop through all MIDI messages which need to be played up until the current playback time
@@ -302,7 +302,7 @@ bool wa_playWave(WarContext* context, WarEntity* entity, u32 sampleCount, s16* o
 
         u8* waveData = &resource->audio.data[audio->sampleIndex];
 
-        u32 sampleBlock = min(sampleCount, (u32)(waveLength - audio->sampleIndex));
+        u32 sampleBlock = MIN(sampleCount, (u32)(waveLength - audio->sampleIndex));
         for (u32 i = 0; i < sampleBlock; i++)
         {
             s32 value = *waveData;
@@ -310,7 +310,7 @@ bool wa_playWave(WarContext* context, WarEntity* entity, u32 sampleCount, s16* o
             value = value << 8;
             value = (s32)(value * volume);
             value += *outputStream;
-            value = clamp(value, INT16_MIN, INT16_MAX);
+            value = CLAMP(value, INT16_MIN, INT16_MAX);
             *outputStream = (s16)value;
 
             waveData++;
@@ -409,10 +409,10 @@ void SDLCALL audioDataCallback(void* userdata, SDL_AudioStream* stream, int addi
                             vec2 position = transform->position;
 
                             rect viewport = map->viewport;
-                            if (!rectContainsf(viewport, position.x, position.y))
+                            if (!rect_containsf(viewport, position.x, position.y))
                             {
-                                vec2 viewportCenter = rectCenter(viewport);
-                                f32 distance = vec2Distance(position, viewportCenter);
+                                vec2 viewportCenter = rect_center(viewport);
+                                f32 distance = vec2_distance(position, viewportCenter);
 
                                 // approximately the distances from the center of the viewport
                                 // begin at 120 pixels, I'm going to set an audible range of 120-200
@@ -422,7 +422,7 @@ void SDLCALL audioDataCallback(void* userdata, SDL_AudioStream* stream, int addi
                                 // > 120 && < 200   ->  interpolate range 120-200 to range 0.75-0
                                 // >= 200           ->  0
                                 volume = 0.75f * (1 - ((distance - 120) / 80));
-                                volume = max(volume, 0);
+                                volume = MAX(volume, 0);
                             }
                         }
 
@@ -662,7 +662,7 @@ WarEntity* wa_playBuildingSelectionSound(WarContext* context, WarEntity* entity)
     if (isBuilding(entity) || isGoingToBuild(entity))
         return wa_createAudio(context, WAR_BUILDING, false);
 
-    s32 hpPercent = percentabi(entity->unit.hp, entity->unit.maxhp);
+    s32 hpPercent = PERCENTABI(entity->unit.hp, entity->unit.maxhp);
     if(hpPercent <= 33)
         return wa_createAudio(context, WAR_FIRE_CRACKLING, false);
 

--- a/src/war_cheats.c
+++ b/src/war_cheats.c
@@ -405,7 +405,7 @@ void wcheat_applyMusicVolCheat(WarContext* context, StringView argument)
     s32 musicVol;
     if (wsv_tryParseS32(argument, &musicVol))
     {
-        musicVol = clamp(musicVol, 0, 100);
+        musicVol = CLAMP(musicVol, 0, 100);
 
         // round the argument to a value multiple of 5
         switch (musicVol % 5)
@@ -437,7 +437,7 @@ void wcheat_applySoundVolCheat(WarContext* context, StringView argument)
     s32 sfxVol;
     if (wsv_tryParseS32(argument, &sfxVol))
     {
-        sfxVol = clamp(sfxVol, 0, 100);
+        sfxVol = CLAMP(sfxVol, 0, 100);
 
         // round the argument to a value multiple of 5
         switch (sfxVol % 5)
@@ -469,7 +469,7 @@ void wcheat_applyGlobalScaleCheat(WarContext* context, StringView argument)
     s32 scale;
     if (wsv_tryParseS32(argument, &scale))
     {
-        scale = clamp(scale, 1, 5);
+        scale = CLAMP(scale, 1, 5);
         wg_setGlobalScale(context, (f32)scale);
         wcheatp_setCheatsFeedback(context, wstr_fromCStringFormat("Global scale set to %d", scale));
     }
@@ -483,7 +483,7 @@ void wcheat_applyGlobalSpeedCheat(WarContext* context, StringView argument)
     s32 speed;
     if (wsv_tryParseS32(argument, &speed))
     {
-        speed = clamp(speed, 1, 5);
+        speed = CLAMP(speed, 1, 5);
         wg_setGlobalSpeed(context, (f32)speed);
         wcheatp_setCheatsFeedback(context, wstr_fromCStringFormat("Global speed set to %d", speed));
     }

--- a/src/war_commands.c
+++ b/src/war_commands.c
@@ -51,8 +51,8 @@ void wcmd_executeMoveCommand(WarContext* context, vec2 targetPoint)
     }
 
     rect targetbbox = rectf(
-        targetPoint.x - halff(bbox.width),
-        targetPoint.y - halff(bbox.height),
+        targetPoint.x - 0.5f * bbox.width,
+        targetPoint.y - 0.5f * bbox.height,
         bbox.width,
         bbox.height);
 
@@ -63,8 +63,8 @@ void wcmd_executeMoveCommand(WarContext* context, vec2 targetPoint)
         assert(entity);
 
         vec2 position = vec2f(
-            rs[i].x + halff(rs[i].width),
-            rs[i].y + halff(rs[i].height));
+            rs[i].x + 0.5f * rs[i].width,
+            rs[i].y + 0.5f * rs[i].height);
 
         position = wmap_mapToTileCoordinatesV(position);
 
@@ -75,8 +75,8 @@ void wcmd_executeMoveCommand(WarContext* context, vec2 targetPoint)
             rs[i].height);
 
         vec2 target = vec2f(
-            targetRect.x + halff(targetRect.width),
-            targetRect.y + halff(targetRect.height));
+            targetRect.x + 0.5f * targetRect.width,
+            targetRect.y + 0.5f * targetRect.height);
 
         target = wmap_mapToTileCoordinatesV(target);
 
@@ -592,7 +592,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
 
@@ -601,7 +601,7 @@ bool wcmd_executeCommand(WarContext* context)
                     command->type = WAR_COMMAND_NONE;
                     return true;
                 }
-                else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+                else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetTile = wmap_screenToMinimapCoordinatesV(context, input->pos);
                     vec2 targetPoint = wmap_tileToMapCoordinatesV(targetTile, true);
@@ -627,7 +627,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -685,7 +685,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -712,7 +712,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -740,7 +740,7 @@ bool wcmd_executeCommand(WarContext* context)
                     command->type = WAR_COMMAND_NONE;
                     return true;
                 }
-                else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+                else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetTile = wmap_screenToMinimapCoordinatesV(context, input->pos);
                     wcmd_executeAttackCommand(context, NULL, targetTile);
@@ -852,7 +852,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     assert(map->selectedEntities.count > 0);
 
@@ -893,7 +893,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     assert(map->selectedEntities.count > 0);
 
@@ -941,7 +941,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     assert(map->selectedEntities.count > 0);
 
@@ -998,7 +998,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1008,7 +1008,7 @@ bool wcmd_executeCommand(WarContext* context)
                     command->type = WAR_COMMAND_NONE;
                     return true;
                 }
-                else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+                else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetTile = wmap_screenToMinimapCoordinatesV(context, input->pos);
                     wcmd_executeRainOfFireCommand(context, targetTile);
@@ -1025,7 +1025,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1035,7 +1035,7 @@ bool wcmd_executeCommand(WarContext* context)
                     command->type = WAR_COMMAND_NONE;
                     return true;
                 }
-                else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+                else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetTile = wmap_screenToMinimapCoordinatesV(context, input->pos);
                     wcmd_executePoisonCloudCommand(context, targetTile);
@@ -1052,7 +1052,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1074,7 +1074,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1096,7 +1096,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1118,7 +1118,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1138,7 +1138,7 @@ bool wcmd_executeCommand(WarContext* context)
         {
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {
-                if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1148,7 +1148,7 @@ bool wcmd_executeCommand(WarContext* context)
                     command->type = WAR_COMMAND_NONE;
                     return true;
                 }
-                else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+                else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetTile = wmap_screenToMinimapCoordinatesV(context, input->pos);
                     wcmd_executeSightCommand(context, targetTile);

--- a/src/war_entities.c
+++ b/src/war_entities.c
@@ -741,7 +741,7 @@ WarEntity* we_findEntityUnderCursor(WarContext* context, bool includeTrees, bool
             }
 
             rect unitRect = wu_getUnitRect(entity);
-            if (rectContainsf(unitRect, targetPoint.x, targetPoint.y))
+            if (rect_containsf(unitRect, targetPoint.x, targetPoint.y))
             {
                 entityUnderCursor = entity;
                 break;
@@ -1108,7 +1108,7 @@ void renderWall(WarContext* context, WarEntity* entity)
 
             s32 tileIndex = 0;
 
-            s32 hpPercent = percentabi(piece->hp, piece->maxhp);
+            s32 hpPercent = PERCENTABI(piece->hp, piece->maxhp);
             if (hpPercent <= 0)
             {
                 tileIndex = (tilesetType == MAP_TILESET_FOREST)
@@ -1251,8 +1251,8 @@ void renderUnit(WarContext* context, WarEntity* entity)
     // the unit is visible if it's partially on the clear areas of the fog
     bool isVisible = isUnitPartiallyVisible(map, entity);
 
-    wr_translate(context, -halff(frameSize.x), -halff(frameSize.y));
-    wr_translate(context, halff(unitSize.x), halff(unitSize.y));
+    wr_translate(context, -0.5f * frameSize.x, -0.5f * frameSize.y);
+    wr_translate(context, 0.5f * unitSize.x, 0.5f * unitSize.y);
     wr_translate(context, position.x, position.y);
 
 #ifdef DEBUG_RENDER_UNIT_INFO
@@ -1282,7 +1282,7 @@ void renderUnit(WarContext* context, WarEntity* entity)
             if (unitComponent->invulnerable)
             {
                 rect unitRect = wu_getUnitSpriteRect(entity);
-                unitRect = rectExpand(unitRect, -1, -1);
+                unitRect = rect_expand(unitRect, -1, -1);
                 wr_strokeRect(context, unitRect, WAR_COLOR_BLUE_INVULNERABLE, 1);
             }
         }
@@ -1314,7 +1314,7 @@ void renderUnit(WarContext* context, WarEntity* entity)
 #endif
 
                 s32 animFrameIndex = (s32)(anim->animTime * anim->frames.count);
-                animFrameIndex = clamp(animFrameIndex, 0, anim->frames.count - 1);
+                animFrameIndex = CLAMP(animFrameIndex, 0, anim->frames.count - 1);
 
                 s32 spriteFrameIndex = anim->frames.items[animFrameIndex];
                 WarSpriteFrame frame = wspr_getSpriteFrame(context, anim->sprite, spriteFrameIndex);
@@ -1410,10 +1410,10 @@ void renderButton(WarContext* context, WarEntity* entity)
             {
                 vec2 backgroundSize = vec2i(button->normalSprite.frameWidth, button->normalSprite.frameHeight);
                 vec2 foregroundSize = vec2i(sprite->sprite.frameWidth, sprite->sprite.frameHeight);
-                vec2 offset = vec2Half(vec2Subv(backgroundSize, foregroundSize));
+                vec2 offset = vec2_half(vec2_subv(backgroundSize, foregroundSize));
 
                 if (button->active)
-                    offset = vec2Addv(offset, vec2i(0, 1));
+                    offset = vec2_addv(offset, vec2i(0, 1));
 
                 wr_translate(context, offset.x, offset.y);
 
@@ -1466,7 +1466,7 @@ void renderProjectile(WarContext* context, WarEntity* entity)
         {
             wr_save(context);
 
-            wr_translate(context, -halfi(sprite->sprite.frameWidth),-halfi(sprite->sprite.frameHeight));
+            wr_translate(context, -sprite->sprite.frameWidth/2,-sprite->sprite.frameHeight/2);
             wr_translate(context, position.x, position.y);
 
             rect r = rectf(0, 0, sprite->sprite.frameWidth, sprite->sprite.frameHeight);
@@ -1478,7 +1478,7 @@ void renderProjectile(WarContext* context, WarEntity* entity)
         {
             wr_save(context);
 
-            wr_translate(context, -halfi(frame.w),-halfi(frame.h));
+            wr_translate(context, -frame.w/2,-frame.h/2);
             wr_translate(context, position.x, position.y);
 
             rect r = rectf(0, 0, frame.w, frame.h);
@@ -1501,7 +1501,7 @@ void renderProjectile(WarContext* context, WarEntity* entity)
 #endif
 
         wr_translate(context, -(f32)frame.dx, -(f32)frame.dy);
-        wr_translate(context, -halff(frame.w), -halff(frame.h));
+        wr_translate(context, -0.5f * frame.w, -0.5f * frame.h);
         wr_translate(context, position.x, position.y);
 
         wspr_updateSpriteImage(context, sprite->sprite, frame.data);
@@ -1613,7 +1613,7 @@ void renderAnimation(WarContext* context, WarEntity* entity)
                 wr_scale(context, anim->scale.x, anim->scale.y);
 
                 s32 animFrameIndex = (s32)(anim->animTime * anim->frames.count);
-                animFrameIndex = clamp(animFrameIndex, 0, anim->frames.count - 1);
+                animFrameIndex = CLAMP(animFrameIndex, 0, anim->frames.count - 1);
 
                 s32 spriteFrameIndex = anim->frames.items[animFrameIndex];
                 WarSpriteFrame frame = wspr_getSpriteFrame(context, anim->sprite, spriteFrameIndex);
@@ -1745,11 +1745,11 @@ void we_renderUnitSelection(WarContext* context)
                 vec2 position = transform->position;
 
                 wr_save(context);
-                wr_translate(context, -halff(frameSize.x), -halff(frameSize.y));
-                wr_translate(context, halff(unitSize.x), halff(unitSize.y));
+                wr_translate(context, -0.5f * frameSize.x, -0.5f * frameSize.y);
+                wr_translate(context, 0.5f * unitSize.x, 0.5f * unitSize.y);
                 wr_translate(context, position.x, position.y);
 
-                rect selr = rectf(halff(frameSize.x - unitSize.x), halff(frameSize.y - unitSize.y), unitSize.x, unitSize.y);
+                rect selr = rectf(0.5f * (frameSize.x - unitSize.x), 0.5f * (frameSize.y - unitSize.y), unitSize.x, unitSize.y);
                 WarColor color = WAR_COLOR_WHITE_SELECTION;
                 if (wu_isFriendlyUnit(context, entity))
                     color = WAR_COLOR_GREEN_SELECTION;
@@ -1914,7 +1914,7 @@ bool we_increaseUnitHp(WarContext* context, WarEntity* entity, s32 hp)
     WarUnitComponent* unit = &entity->unit;
 
     unit->hp += hp;
-    unit->hp = min(unit->hp, unit->maxhp);
+    unit->hp = MIN(unit->hp, unit->maxhp);
 
     return true;
 }
@@ -1928,7 +1928,7 @@ bool we_decreaseUnitHp(WarContext* context, WarEntity* entity, s32 hp)
     WarUnitComponent* unit = &entity->unit;
 
     unit->hp -= hp;
-    unit->hp = max(unit->hp, 0);
+    unit->hp = MAX(unit->hp, 0);
 
     return true;
 }
@@ -1944,7 +1944,7 @@ bool we_decreaseUnitMana(WarContext* context, WarEntity* entity, s32 mana)
         return false;
     }
 
-    unit->mana = max(unit->mana - mana, 0);
+    unit->mana = MAX(unit->mana - mana, 0);
     return true;
 }
 
@@ -1955,7 +1955,7 @@ void we_increaseUnitMana(WarContext* context, WarEntity* entity, s32 mana)
     assert(isUnit(entity));
 
     WarUnitComponent* unit = &entity->unit;
-    unit->mana = clamp(unit->mana + mana, 0, unit->maxMana);
+    unit->mana = CLAMP(unit->mana + mana, 0, unit->maxMana);
 }
 
 bool we_enoughFarmFood(WarContext* context, WarPlayerInfo* player)
@@ -2137,7 +2137,7 @@ WarEntity* we_getAttackTarget(WarContext* context, WarEntity* entity)
 
 s32 we_getTotalDamage(s32 minDamage, s32 rndDamage, s32 armor)
 {
-    return minDamage + max(rndDamage - armor, 0);
+    return minDamage + MAX(rndDamage - armor, 0);
 }
 
 void we_takeDamage(WarContext* context, WarEntity *entity, s32 minDamage, s32 rndDamage)
@@ -2193,7 +2193,7 @@ void we_takeDamage(WarContext* context, WarEntity *entity, s32 minDamage, s32 rn
     }
     else if (wu_isBuildingUnit(entity))
     {
-        s32 hpPercent = percentabi(unit->hp, unit->maxhp);
+        s32 hpPercent = PERCENTABI(unit->hp, unit->maxhp);
         if(hpPercent <= 33)
         {
             if (!wanim_containsAnimation(context, entity, wsv_fromCString("hugeDamage")))
@@ -2221,7 +2221,7 @@ void we_takeWallDamage(WarContext* context, WarEntity* entity, WarWallPiece* pie
     // Minimal damage + [Random damage - Enemy's Armor]
     s32 damage = we_getTotalDamage(minDamage, rndDamage, 0);
     piece->hp -= damage;
-    piece->hp = max(piece->hp, 0);
+    piece->hp = MAX(piece->hp, 0);
 }
 
 void we_rangeAttack(WarContext* context, WarEntity* entity, WarEntity* targetEntity)
@@ -2349,7 +2349,7 @@ s32 mine(WarContext* context, WarEntity* goldmine, s32 amount)
         amount = unit->amount;
 
     unit->amount -= amount;
-    unit->amount = max(unit->amount, 0);
+    unit->amount = MAX(unit->amount, 0);
 
     if (unit->amount == 0)
     {

--- a/src/war_font.c
+++ b/src/war_font.c
@@ -254,12 +254,12 @@ vec2 wfont_getAlignmentOffset(WarTextAlignment horizontalAlign, WarTextAlignment
         }
         case WAR_TEXT_ALIGN_CENTER:
         {
-            offset.x = ceilf(halff(boundings.x - textSize.x));
+            offset.x = ceilf(0.5f * (boundings.x - textSize.x));
             break;
         }
         case WAR_TEXT_ALIGN_RIGHT:
         {
-            offset.x = ceilf(boundings.x - textSize.x);
+            offset.x = ceilf(0.5f * (boundings.x - textSize.x));
             break;
         }
         default:
@@ -278,7 +278,7 @@ vec2 wfont_getAlignmentOffset(WarTextAlignment horizontalAlign, WarTextAlignment
         }
         case WAR_TEXT_ALIGN_MIDDLE:
         {
-            offset.y = ceilf(halff(boundings.y) - halff(textSize.y));
+            offset.y = ceilf(0.5f * (boundings.y - textSize.y));
             break;
         }
         case WAR_TEXT_ALIGN_BOTTOM:
@@ -309,7 +309,7 @@ f32 wfont_getLineAlignmentOffset(WarTextAlignment lineAlign, f32 width, f32 line
         }
         case WAR_TEXT_ALIGN_CENTER:
         {
-            offset = ceilf(halff(width - lineWidth));
+            offset = ceilf(0.5f * (width - lineWidth));
             break;
         }
         case WAR_TEXT_ALIGN_RIGHT:
@@ -482,7 +482,7 @@ vec2 wfont_measureSingleSpriteText(StringView text, s32 length, WarFontParams pa
             rect rs = params.fontData.data[getCharIndex(c)];
 
             size.x += (rs.width + params.fontData.advance) * scale;
-            size.y = max(size.y, rs.height * scale);
+            size.y = MAX(size.y, rs.height * scale);
         }
     }
 
@@ -503,7 +503,7 @@ vec2 wfont_measureMultiSpriteText(StringView text, f32 width, WarFontParams para
 
     for (s32 i = 0; i < linesCount; i++)
     {
-        size.x = max(size.x, lines[i].width);
+        size.x = MAX(size.x, lines[i].width);
         size.y += lineHeight * scale;
     }
 
@@ -586,7 +586,7 @@ void wfont_renderSingleSpriteText(WarContext* context, StringView text, f32 x, f
     wr_save(context);
     wr_translate(context, x, y);
 
-    if (!vec2IsZero(params.boundings))
+    if (!VEC2_IS_ZERO(params.boundings))
     {
         vec2 textOffset = wfont_getAlignmentOffset(params.horizontalAlign, params.verticalAlign, params.boundings, textSize);
         wr_translate(context, textOffset.x, textOffset.y);
@@ -695,7 +695,7 @@ void wfont_renderMultiSpriteText(WarContext* context, StringView text, f32 x, f3
         if (params.highlightIndex >= lineStartIndex && params.highlightIndex < lineStartIndex + lineLength)
         {
             s32 highlightIndex = params.highlightIndex - lineStartIndex;
-            s32 highlightCount = min(params.highlightCount, lineLength - highlightIndex);
+            s32 highlightCount = MIN(params.highlightCount, lineLength - highlightIndex);
 
             x = wfont_renderSingleSpriteTextSpan(context, lineView,
                                         0, highlightIndex,
@@ -728,7 +728,7 @@ void wfont_renderMultiSpriteText(WarContext* context, StringView text, f32 x, f3
         else if (params.highlightIndex < lineStartIndex &&
                  params.highlightIndex + params.highlightCount >= lineStartIndex)
         {
-            s32 highlightCount = min(params.highlightIndex + params.highlightCount - lineStartIndex, lineLength);
+            s32 highlightCount = MIN(params.highlightIndex + params.highlightCount - lineStartIndex, lineLength);
 
             x = wfont_renderSingleSpriteTextSpan(context, lineView,
                                         0, highlightCount,

--- a/src/war_game.c
+++ b/src/war_game.c
@@ -326,7 +326,7 @@ void wg_setWindowSize(WarContext* context, s32 width, s32 height)
 
 void wg_setGlobalScale(WarContext* context, f32 scale)
 {
-    context->globalScale = max(scale, 1.0f);
+    context->globalScale = MAX(scale, 1.0f);
     logDebug("set global scale to: %.2f", context->globalScale);
 
     s32 newWidth = (s32)(context->originalWindowWidth * context->globalScale);
@@ -341,7 +341,7 @@ void wg_changeGlobalScale(WarContext* context, f32 deltaScale)
 
 void wg_setGlobalSpeed(WarContext* context, f32 speed)
 {
-    context->globalSpeed = max(speed, 1.0f);
+    context->globalSpeed = MAX(speed, 1.0f);
     logDebug("set global speed to: %.2f", context->globalSpeed);
 }
 
@@ -352,7 +352,7 @@ void wg_changeGlobalSpeed(WarContext* context, f32 deltaSpeed)
 
 void wg_setMusicVolume(WarContext* context, f32 volume)
 {
-    context->musicVolume = clamp(volume, 0.0f, 1.0f);
+    context->musicVolume = CLAMP(volume, 0.0f, 1.0f);
     logDebug("set music volume to: %.2f", context->musicVolume);
 }
 
@@ -363,7 +363,7 @@ void wg_changeMusicVolume(WarContext* context, f32 deltaVolume)
 
 void wg_setSoundVolume(WarContext* context, f32 volume)
 {
-    context->soundVolume = clamp(volume, 0.0f, 1.0f);
+    context->soundVolume = CLAMP(volume, 0.0f, 1.0f);
     logDebug("set sound volume to: %.2f", context->soundVolume);
 }
 
@@ -583,7 +583,7 @@ void wg_updateGame(WarContext* context)
 
     if (context->transitionDelay > 0)
     {
-        context->transitionDelay = max(context->transitionDelay - context->deltaTime, 0.0f);
+        context->transitionDelay = MAX(context->transitionDelay - context->deltaTime, 0.0f);
         return;
     }
 
@@ -639,30 +639,10 @@ void wg_presentGame(WarContext *context)
     f32 currentTime = SDL_GetTicks() / 1000.0f;
     context->deltaTime = (currentTime - context->time);
 
-    // This code is good in theory, but the sleep resolution on different OSes
-    // varies, so Sleep in Windows may take a longer time than specified.
-    //
-    // On Linux I should do a do {..} while (); using the nanosleep function
-    // and check for interrutions that wake up the thread before.
-    //
-    // SDL_Delay((s32)((SECONDS_PER_FRAME - context->deltaTime) * 1000));
-    // currentTime = SDL_GetTicks() / 1000.0f;
-    // context->deltaTime = (currentTime - context->time);
-
-    // This was the previous code that wait until the end of the frame
-    // but this burn too much CPU, so it's better the alternative of
-    // sleep the process and save CPU usage and battery.
-    //
-    // Going back to this code for now, until we get a consistent game loop with sleep.
-    {
-        TracyCZoneN(waitCtx, "FrameWait", 1);
-        while (context->deltaTime <= SECONDS_PER_FRAME)
-        {
-            currentTime = SDL_GetTicks() / 1000.0f;
-            context->deltaTime = (currentTime - context->time);
-        }
-        TracyCZoneEnd(waitCtx);
-    }
+    TracyCZoneN(waitCtx, "FrameWait", 1);
+    // sleep until the end of the frame to save CPU and battery, but only if we have time left in the frame
+    SDL_Delay((s32)(MAX(0.0f, SECONDS_PER_FRAME - context->deltaTime) * 1000));
+    TracyCZoneEnd(waitCtx);
 
     context->time = currentTime;
     context->fps = (u32)(1.0f / context->deltaTime);

--- a/src/war_map.c
+++ b/src/war_map.c
@@ -58,7 +58,7 @@ vec2 wmap_getDirFromArrowKeys(WarContext* context)
     else if (isKeyPressed(input, WAR_KEY_UP))
         dir.y = -1;
 
-    dir = vec2Normalize(dir);
+    dir = vec2_normalize(dir);
     return dir;
 }
 
@@ -78,7 +78,7 @@ vec2 wmap_getDirFromMousePos(WarContext* context)
     else if (input->pos.y > context->originalWindowHeight - MAP_EDGE_SCROLL_GAP)
         dir.y = 1;
 
-    dir = vec2Normalize(dir);
+    dir = vec2_normalize(dir);
     return dir;
 }
 
@@ -89,8 +89,8 @@ vec2 wmap_screenToMapCoordinatesV(WarContext* context, vec2 v)
     rect mapPanel = map->mapPanel;
     rect viewport = map->viewport;
 
-    v = vec2Translatef(v, -mapPanel.x, -mapPanel.y);
-    v = vec2Translatef(v, viewport.x, viewport.y);
+    v = vec2_translatef(v, -mapPanel.x, -mapPanel.y);
+    v = vec2_translatef(v, viewport.x, viewport.y);
     return v;
 }
 
@@ -100,7 +100,7 @@ vec2 wmap_screenToMinimapCoordinatesV(WarContext* context, vec2 v)
 
     rect minimapPanel = map->minimapPanel;
 
-    v = vec2Translatef(v, -minimapPanel.x, -minimapPanel.y);
+    v = vec2_translatef(v, -minimapPanel.x, -minimapPanel.y);
     return v;
 }
 
@@ -111,8 +111,8 @@ rect wmap_screenToMapCoordinatesR(WarContext* context, rect r)
     rect mapPanel = map->mapPanel;
     rect viewport = map->viewport;
 
-    r = rectTranslatef(r, -mapPanel.x, -mapPanel.y);
-    r = rectTranslatef(r, viewport.x, viewport.y);
+    r = rect_translatef(r, -mapPanel.x, -mapPanel.y);
+    r = rect_translatef(r, viewport.x, viewport.y);
     return r;
 }
 
@@ -120,8 +120,8 @@ vec2 wmap_mapToScreenCoordinatesV(WarContext* context, vec2 v)
 {
     WarMap* map = context->map;
 
-    v = vec2Translatef(v, -map->viewport.x, -map->viewport.y);
-    v = vec2Translatef(v, map->mapPanel.x, map->mapPanel.y);
+    v = vec2_translatef(v, -map->viewport.x, -map->viewport.y);
+    v = vec2_translatef(v, map->mapPanel.x, map->mapPanel.y);
     return v;
 }
 
@@ -129,8 +129,8 @@ rect wmap_mapToScreenCoordinatesR(WarContext* context, rect r)
 {
     WarMap* map = context->map;
 
-    r = rectTranslatef(r, -map->viewport.x, -map->viewport.y);
-    r = rectTranslatef(r, map->mapPanel.x, map->mapPanel.y);
+    r = rect_translatef(r, -map->viewport.x, -map->viewport.y);
+    r = rect_translatef(r, map->mapPanel.x, map->mapPanel.y);
     return r;
 }
 
@@ -148,8 +148,8 @@ vec2 wmap_tileToMapCoordinatesV(vec2 v, bool centeredInTile)
 
     if (centeredInTile)
     {
-        v.x += halfi(MEGA_TILE_WIDTH);
-        v.y += halfi(MEGA_TILE_HEIGHT);
+        v.x += MEGA_TILE_WIDTH/2;
+        v.y += MEGA_TILE_HEIGHT/2;
     }
 
     return v;
@@ -164,8 +164,8 @@ vec2 wmap_minimapToViewportCoordinatesV(WarContext* context, vec2 v)
 
     vec2 minimapViewportSize = vec2f(MINIMAP_VIEWPORT_WIDTH, MINIMAP_VIEWPORT_HEIGHT);
 
-    v = vec2Translatef(v, -minimapViewportSize.x / 2, -minimapViewportSize.y / 2);
-    v = vec2Clampv(v, VEC2_ZERO, vec2Subv(minimapPanelSize, minimapViewportSize));
+    v = vec2_translatef(v, -minimapViewportSize.x / 2, -minimapViewportSize.y / 2);
+    v = vec2_clampv(v, VEC2_ZERO, vec2_subv(minimapPanelSize, minimapViewportSize));
     return v;
 }
 
@@ -215,7 +215,7 @@ void wmap_setUnitMapTileState(WarMap* map, WarEntity* entity, WarMapTileState ti
     vec2 position = wu_getUnitPosition(entity, true);
     vec2 unitSize = wu_getUnitSize(entity);
     rect unitRect = rectv(position, unitSize);
-    unitRect = rectExpand(unitRect, (f32)sight, (f32)sight);
+    unitRect = rect_expand(unitRect, (f32)sight, (f32)sight);
 
     wmap_setMapTileState(map, (s32)unitRect.x, (s32)unitRect.y, (s32)unitRect.width, (s32)unitRect.height, tileState);
 }
@@ -876,7 +876,7 @@ void updateViewport(WarContext *context)
     if (isButtonPressed(input, WAR_MOUSE_LEFT))
     {
         // check if the click is inside the minimap panel
-        if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
         {
             vec2 minimapSize = vec2i(MINIMAP_WIDTH, MINIMAP_HEIGHT);
             vec2 offset = wmap_screenToMinimapCoordinatesV(context, input->pos);
@@ -906,7 +906,7 @@ void updateViewport(WarContext *context)
         }
     }
 
-    map->isScrolling = !vec2IsZero(dir);
+    map->isScrolling = !VEC2_IS_ZERO(dir);
     if (map->isScrolling)
     {
         assert(mouseScroll || keyScroll);
@@ -918,10 +918,10 @@ void updateViewport(WarContext *context)
             scrollSpeed = getMapScrollSpeed(map->settings.keyScrollSpeed);
 
         map->viewport.x += scrollSpeed * dir.x * context->deltaTime;
-        map->viewport.x = clamp(map->viewport.x, 0.0f, MAP_WIDTH - map->viewport.width);
+        map->viewport.x = CLAMP(map->viewport.x, 0.0f, MAP_WIDTH - map->viewport.width);
 
         map->viewport.y += scrollSpeed * dir.y * context->deltaTime;
-        map->viewport.y = clamp(map->viewport.y, 0.0f, MAP_HEIGHT - map->viewport.height);
+        map->viewport.y = CLAMP(map->viewport.y, 0.0f, MAP_HEIGHT - map->viewport.height);
     }
     else
     {
@@ -946,7 +946,7 @@ void updateDragRect(WarContext* context)
 
     if (isButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if(rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             if (!input->isDragging)
             {
@@ -977,7 +977,7 @@ void updateSelection(WarContext* context)
         if (!map->wasScrolling)
         {
             // check if the click is inside the map panel
-            if(input->wasDragging || rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+            if(input->wasDragging || rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
             {
                 WarEntityList newSelectedEntities;
                 WarEntityListInit(&newSelectedEntities, WarEntityListNonFreeOptions);
@@ -1019,7 +1019,7 @@ void updateSelection(WarContext* context)
                             }
 
                             rect unitRect = wu_getUnitRect(entity);
-                            if (rectIntersects(pointerRect, unitRect))
+                            if (rect_intersects(pointerRect, unitRect))
                             {
                                 WarEntityListAdd(&newSelectedEntities, entity);
                             }
@@ -1113,7 +1113,7 @@ void updateSelection(WarContext* context)
                 wmap_clearSelection(context);
 
                 // and add the new selection
-                s32 selectedEntitiesCount = min(newSelectedEntities.count, 4);
+                s32 selectedEntitiesCount = MIN(newSelectedEntities.count, 4);
                 for (s32 i = 0; i < selectedEntitiesCount; i++)
                 {
                     WarEntity* entity = newSelectedEntities.items[i];
@@ -1136,7 +1136,7 @@ void updateTreesEdit(WarContext* context)
 
     if (wasButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             vec2 pointerPos = wmap_screenToMapCoordinatesV(context, input->pos);
             pointerPos =  wmap_mapToTileCoordinatesV(pointerPos);
@@ -1176,7 +1176,7 @@ void updateRoadsEdit(WarContext* context)
 
     if (wasButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             vec2 pointerPos = wmap_screenToMapCoordinatesV(context, input->pos);
             pointerPos =  wmap_mapToTileCoordinatesV(pointerPos);
@@ -1211,7 +1211,7 @@ void updateWallsEdit(WarContext* context)
 
     if (wasButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             vec2 pointerPos = wmap_screenToMapCoordinatesV(context, input->pos);
             pointerPos =  wmap_mapToTileCoordinatesV(pointerPos);
@@ -1251,7 +1251,7 @@ void updateRuinsEdit(WarContext* context)
 
     if (wasButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             vec2 pointerPos = wmap_screenToMapCoordinatesV(context, input->pos);
             pointerPos =  wmap_mapToTileCoordinatesV(pointerPos);
@@ -1286,7 +1286,7 @@ void updateRainOfFireEdit(WarContext* context)
 
     if (wasButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             rect viewport = map->viewport;
 
@@ -1309,7 +1309,7 @@ void updateAddUnit(WarContext* context)
 
     if (wasButtonPressed(input, WAR_MOUSE_LEFT))
     {
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             vec2 pointerPos = wmap_screenToMapCoordinatesV(context, input->pos);
             pointerPos =  wmap_mapToTileCoordinatesV(pointerPos);
@@ -1460,7 +1460,7 @@ void updateCommandFromRightClick(WarContext* context)
             if (selEntitiesCount > 0)
             {
                 // if the right click was on the map
-                if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+                if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 targetPoint = wmap_screenToMapCoordinatesV(context, input->pos);
                     vec2 targetTile = wmap_mapToTileCoordinatesV(targetPoint);
@@ -1539,7 +1539,7 @@ void updateCommandFromRightClick(WarContext* context)
                     }
                 }
                 // if the right click was on the minimap
-                else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+                else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
                 {
                     vec2 offset = wmap_screenToMinimapCoordinatesV(context, input->pos);
                     vec2 targetPoint = wmap_tileToMapCoordinatesV(offset, true);
@@ -1796,7 +1796,7 @@ void updateMapCursor(WarContext* context)
     WarEntity* entity = we_findUIEntity(context, wsv_fromCString("cursor"));
     if (entity)
     {
-        entity->transform.position = vec2Subv(input->pos, entity->cursor.hot);
+        entity->transform.position = vec2_subv(input->pos, entity->cursor.hot);
 
         if (!map->playing)
         {
@@ -1810,7 +1810,7 @@ void updateMapCursor(WarContext* context)
             return;
         }
 
-        if (rectContainsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
             WarUnitCommand* command = &map->command;
             switch (command->type)
@@ -1941,7 +1941,7 @@ void updateMapCursor(WarContext* context)
                 }
             }
         }
-        else if (rectContainsf(map->minimapPanel, input->pos.x, input->pos.y))
+        else if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
         {
             WarUnitCommand* command = &map->command;
             switch (command->type)
@@ -2054,7 +2054,7 @@ void updateMagic(WarContext* context)
             {
                 if (wu_isSummonUnit(entity))
                 {
-                    unit->mana = max(unit->mana - 1, 0);
+                    unit->mana = MAX(unit->mana - 1, 0);
 
                     // when the mana runs out the summoned units will die
                     if (unit->mana == 0)
@@ -2075,7 +2075,7 @@ void updateMagic(WarContext* context)
                 {
                     // the magic units have a mana regeneration rate of roughly 1 point/sec
                     // so a magic unit will spend almost 4 minutes to fill its mana when its rans out
-                    unit->mana = min(unit->mana + 1, unit->maxMana);
+                    unit->mana = MIN(unit->mana + 1, unit->maxMana);
                 }
 
                 unit->manaTime = 1.0f;
@@ -2216,7 +2216,7 @@ void updateFoW(WarContext* context)
         {
             WarSightComponent* sight = &entity->sight;
 
-            rect r = rectExpand(rectv(sight->position, VEC2_ONE), 3, 3);
+            rect r = rect_expand(rectv(sight->position, VEC2_ONE), 3, 3);
             wmap_setMapTileState(map, (s32)r.x, (s32)r.y, (s32)r.width, (s32)r.height, MAP_TILE_STATE_VISIBLE);
         }
     }
@@ -2680,7 +2680,7 @@ void renderUnitPaths(WarContext* context)
                 for(s32 k = moveState->move.positionIndex; k < positions.count; k++)
                 {
                     vec2 pos = wmap_tileToMapCoordinatesV(positions.items[k], true);
-                    pos = vec2Subv(pos, vec2i(2, 2));
+                    pos = vec2_subv(pos, vec2i(2, 2));
                     wr_fillRect(context, rectv(pos, vec2i(4, 4)), wr_getColorFromList(entity->id));
                 }
 

--- a/src/war_map_menu.c
+++ b/src/war_map_menu.c
@@ -49,7 +49,7 @@ void wmm_createMenu(WarContext* context)
     WarMap* map = context->map;
     WarPlayerInfo* player = &map->players[0];
 
-    vec2 menuPanel = rectTopLeft(map->menuPanel);
+    vec2 menuPanel = RECT_TOP_LEFT(map->menuPanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef mediumNormalRef = imageResourceRef(239);
@@ -70,7 +70,7 @@ void wmm_createMenu(WarContext* context)
 
     uiEntity = wui_createUIText(
         context, wstr_fromCString("txtMenuHeader"), 1, 10, wstr_fromCString("Warcraft"),
-        vec2Addv(menuPanel, vec2i(0, 10)));
+        vec2_addv(menuPanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->menuPanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
@@ -82,7 +82,7 @@ void wmm_createMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 25)));
+        vec2_addv(menuPanel, vec2i(20, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonHotKey(uiEntity, WAR_KEY_S);
     setUITextHighlight(uiEntity, 0, 1);
@@ -93,7 +93,7 @@ void wmm_createMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(78, 25)));
+        vec2_addv(menuPanel, vec2i(78, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonHotKey(uiEntity, WAR_KEY_L);
     setUITextHighlight(uiEntity, 0, 1);
@@ -104,7 +104,7 @@ void wmm_createMenu(WarContext* context)
         mediumNormalRef,
         mediumPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 45)));
+        vec2_addv(menuPanel, vec2i(20, 45)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleOptions);
     setUIButtonHotKey(uiEntity, WAR_KEY_O);
@@ -116,7 +116,7 @@ void wmm_createMenu(WarContext* context)
         mediumNormalRef,
         mediumPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 65)));
+        vec2_addv(menuPanel, vec2i(20, 65)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleObjectives);
     setUIButtonHotKey(uiEntity, WAR_KEY_J);
@@ -128,7 +128,7 @@ void wmm_createMenu(WarContext* context)
         mediumNormalRef,
         mediumPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 85)));
+        vec2_addv(menuPanel, vec2i(20, 85)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleRestart);
     setUIButtonHotKey(uiEntity, WAR_KEY_R);
@@ -140,7 +140,7 @@ void wmm_createMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 105)));
+        vec2_addv(menuPanel, vec2i(20, 105)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleContinue);
     setUIButtonHotKey(uiEntity, WAR_KEY_C);
@@ -152,7 +152,7 @@ void wmm_createMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(78, 105)));
+        vec2_addv(menuPanel, vec2i(78, 105)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleQuit);
     setUIButtonHotKey(uiEntity, WAR_KEY_Q);
@@ -163,7 +163,7 @@ void wmm_createOptionsMenu(WarContext* context)
 {
     WarMap* map = context->map;
 
-    vec2 menuPanel = rectTopLeft(map->menuPanel);
+    vec2 menuPanel = RECT_TOP_LEFT(map->menuPanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef smallNormalRef = imageResourceRef(241);
@@ -176,77 +176,77 @@ void wmm_createOptionsMenu(WarContext* context)
     WarEntity* uiEntity;
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsHeader"),
-        1, 10, wstr_fromCString("Options"), vec2Addv(menuPanel, vec2i(0, 10)));
+        1, 10, wstr_fromCString("Options"), vec2_addv(menuPanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->menuPanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsGameSpeedLabel"),
-        1, 10, wstr_fromCString("Game Speed"), vec2Addv(menuPanel, vec2i(0, 25)));
+        1, 10, wstr_fromCString("Game Speed"), vec2_addv(menuPanel, vec2i(0, 25)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(75, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_RIGHT);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsMusicVolLabel"),
-        1, 10, wstr_fromCString("Music Vol"), vec2Addv(menuPanel, vec2i(0, 42)));
+        1, 10, wstr_fromCString("Music Vol"), vec2_addv(menuPanel, vec2i(0, 42)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(75, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_RIGHT);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsSFXVolLabel"),
-        1, 10, wstr_fromCString("SFX Vol"), vec2Addv(menuPanel, vec2i(0, 59)));
+        1, 10, wstr_fromCString("SFX Vol"), vec2_addv(menuPanel, vec2i(0, 59)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(75, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_RIGHT);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsMouseScrollLabel"),
-        1, 10, wstr_fromCString("Mouse Scroll"), vec2Addv(menuPanel, vec2i(0, 76)));
+        1, 10, wstr_fromCString("Mouse Scroll"), vec2_addv(menuPanel, vec2i(0, 76)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(75, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_RIGHT);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsKeyScrollLabel"),
-        1, 10, wstr_fromCString("Key Scroll"), vec2Addv(menuPanel, vec2i(0, 93)));
+        1, 10, wstr_fromCString("Key Scroll"), vec2_addv(menuPanel, vec2i(0, 93)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(75, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_RIGHT);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsGameSpeedValue"),
-        1, 10, wstr_fromCString("Fastest"), vec2Addv(menuPanel, vec2i(92, 25)));
+        1, 10, wstr_fromCString("Fastest"), vec2_addv(menuPanel, vec2i(92, 25)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(42, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsMusicVolValue"),
-        1, 10, wstr_fromCString("100"), vec2Addv(menuPanel, vec2i(92, 42)));
+        1, 10, wstr_fromCString("100"), vec2_addv(menuPanel, vec2i(92, 42)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(42, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsSFXVolValue"),
-        1, 10, wstr_fromCString("82"), vec2Addv(menuPanel, vec2i(92, 59)));
+        1, 10, wstr_fromCString("82"), vec2_addv(menuPanel, vec2i(92, 59)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(42, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsMouseScrollValue"),
-        1, 10, wstr_fromCString("Slowest"), vec2Addv(menuPanel, vec2i(92, 76)));
+        1, 10, wstr_fromCString("Slowest"), vec2_addv(menuPanel, vec2i(92, 76)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(42, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtOptionsKeyScrollValue"),
-        1, 10, wstr_fromCString("Normal"), vec2Addv(menuPanel, vec2i(92, 93)));
+        1, 10, wstr_fromCString("Normal"), vec2_addv(menuPanel, vec2i(92, 93)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(42, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
@@ -257,7 +257,7 @@ void wmm_createOptionsMenu(WarContext* context)
         leftArrowNormalRef,
         leftArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(76, 22)));
+        vec2_addv(menuPanel, vec2i(76, 22)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleGameSpeedDec);
 
@@ -266,7 +266,7 @@ void wmm_createOptionsMenu(WarContext* context)
         rightArrowNormalRef,
         rightArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(133, 22)));
+        vec2_addv(menuPanel, vec2i(133, 22)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleGameSpeedInc);
 
@@ -275,7 +275,7 @@ void wmm_createOptionsMenu(WarContext* context)
         leftArrowNormalRef,
         leftArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(76, 39)));
+        vec2_addv(menuPanel, vec2i(76, 39)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleMusicVolDec);
 
@@ -284,7 +284,7 @@ void wmm_createOptionsMenu(WarContext* context)
         rightArrowNormalRef,
         rightArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(133, 39)));
+        vec2_addv(menuPanel, vec2i(133, 39)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleMusicVolInc);
 
@@ -293,7 +293,7 @@ void wmm_createOptionsMenu(WarContext* context)
         leftArrowNormalRef,
         leftArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(76, 56)));
+        vec2_addv(menuPanel, vec2i(76, 56)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleSfxVolDec);
 
@@ -302,7 +302,7 @@ void wmm_createOptionsMenu(WarContext* context)
         rightArrowNormalRef,
         rightArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(133, 56)));
+        vec2_addv(menuPanel, vec2i(133, 56)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleSfxVolInc);
 
@@ -311,7 +311,7 @@ void wmm_createOptionsMenu(WarContext* context)
         leftArrowNormalRef,
         leftArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(76, 73)));
+        vec2_addv(menuPanel, vec2i(76, 73)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleMouseScrollSpeedDec);
 
@@ -320,7 +320,7 @@ void wmm_createOptionsMenu(WarContext* context)
         rightArrowNormalRef,
         rightArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(133, 73)));
+        vec2_addv(menuPanel, vec2i(133, 73)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleMouseScrollSpeedInc);
 
@@ -329,7 +329,7 @@ void wmm_createOptionsMenu(WarContext* context)
         leftArrowNormalRef,
         leftArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(76, 90)));
+        vec2_addv(menuPanel, vec2i(76, 90)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleKeyScrollSpeedDec);
 
@@ -338,7 +338,7 @@ void wmm_createOptionsMenu(WarContext* context)
         rightArrowNormalRef,
         rightArrowPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(133, 90)));
+        vec2_addv(menuPanel, vec2i(133, 90)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleKeyScrollSpeedInc);
 
@@ -348,7 +348,7 @@ void wmm_createOptionsMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 115)));
+        vec2_addv(menuPanel, vec2i(20, 115)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleOptionsOk);
     setUIButtonHotKey(uiEntity, WAR_KEY_O);
@@ -360,7 +360,7 @@ void wmm_createOptionsMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(78, 115)));
+        vec2_addv(menuPanel, vec2i(78, 115)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleOptionsCancel);
     setUIButtonHotKey(uiEntity, WAR_KEY_C);
@@ -376,7 +376,7 @@ void createObjectivesMenu(WarContext* context)
 
     WarCampaignMapData campaignData = wcamp_getCampaignData(wmap_getCampaignMapTypeByLevelInfoIndex(map->levelInfoIndex));
 
-    vec2 menuPanel = rectTopLeft(map->menuPanel);
+    vec2 menuPanel = RECT_TOP_LEFT(map->menuPanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef mediumNormalRef = imageResourceRef(239);
@@ -385,14 +385,14 @@ void createObjectivesMenu(WarContext* context)
     WarEntity* uiEntity;
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtObjectivesHeader"),
-        1, 10, wstr_fromCString("Objectives"), vec2Addv(menuPanel, vec2i(0, 10)));
+        1, 10, wstr_fromCString("Objectives"), vec2_addv(menuPanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->menuPanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
     setUITextVerticalAlign(uiEntity, WAR_TEXT_ALIGN_MIDDLE);
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtObjectivesText"),
-        1, 10, campaignData.objectives, vec2Addv(menuPanel, vec2i(10, 26)));
+        1, 10, campaignData.objectives, vec2_addv(menuPanel, vec2i(10, 26)));
     setUIEntityStatus(uiEntity, false);
     setUITextMultiline(uiEntity, true);
     setUITextBoundings(uiEntity, vec2f(map->menuPanel.width - 20, 75));
@@ -408,7 +408,7 @@ void createObjectivesMenu(WarContext* context)
         mediumNormalRef,
         mediumPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 105)));
+        vec2_addv(menuPanel, vec2i(20, 105)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleObjectivesMenu);
     setUIButtonHotKey(uiEntity, WAR_KEY_M);
@@ -420,7 +420,7 @@ void createRestartMenu(WarContext* context)
     WarMap* map = context->map;
     WarPlayerInfo* player = &map->players[0];
 
-    vec2 messagePanel = rectTopLeft(map->messagePanel);
+    vec2 messagePanel = RECT_TOP_LEFT(map->messagePanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef smallNormalRef = imageResourceRef(241);
@@ -433,7 +433,7 @@ void createRestartMenu(WarContext* context)
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtRestartText"),
         1, 10, wstr_fromCString("Are you sure you want to restart?"),
-        vec2Addv(messagePanel, vec2i(0, 10)));
+        vec2_addv(messagePanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->messagePanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
@@ -445,7 +445,7 @@ void createRestartMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(20, 25)));
+        vec2_addv(messagePanel, vec2i(20, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleRestartRestart);
     setUIButtonHotKey(uiEntity, WAR_KEY_R);
@@ -457,7 +457,7 @@ void createRestartMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(210, 25)));
+        vec2_addv(messagePanel, vec2i(210, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleRestartCancel);
     setUIButtonHotKey(uiEntity, WAR_KEY_C);
@@ -468,7 +468,7 @@ void wmm_createGameOverMenu(WarContext* context)
 {
     WarMap* map = context->map;
 
-    vec2 messagePanel = rectTopLeft(map->messagePanel);
+    vec2 messagePanel = RECT_TOP_LEFT(map->messagePanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef smallNormalRef = imageResourceRef(241);
@@ -478,7 +478,7 @@ void wmm_createGameOverMenu(WarContext* context)
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtGameOverText"),
         1, 10, wstr_fromCString("You are victorious!"),
-        vec2Addv(messagePanel, vec2i(0, 10)));
+        vec2_addv(messagePanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->messagePanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
@@ -490,7 +490,7 @@ void wmm_createGameOverMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(20, 25)));
+        vec2_addv(messagePanel, vec2i(20, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleGameOverSave);
     setUIButtonHotKey(uiEntity, WAR_KEY_S);
@@ -502,7 +502,7 @@ void wmm_createGameOverMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(210, 25)));
+        vec2_addv(messagePanel, vec2i(210, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleGameOverContinue);
     setUIButtonHotKey(uiEntity, WAR_KEY_C);
@@ -514,7 +514,7 @@ void wmm_createGameOverMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(116, 25)));
+        vec2_addv(messagePanel, vec2i(116, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleGameOverContinue);
     setUIButtonHotKey(uiEntity, WAR_KEY_O);
@@ -525,7 +525,7 @@ void wmm_createQuitMenu(WarContext* context)
 {
     WarMap* map = context->map;
 
-    vec2 messagePanel = rectTopLeft(map->messagePanel);
+    vec2 messagePanel = RECT_TOP_LEFT(map->messagePanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef smallNormalRef = imageResourceRef(241);
@@ -535,7 +535,7 @@ void wmm_createQuitMenu(WarContext* context)
 
     uiEntity = wui_createUIText(context, wstr_fromCString("txtQuitText"),
         1, 10, wstr_fromCString("Are you sure you want to quit?"),
-        vec2Addv(messagePanel, vec2i(0, 10)));
+        vec2_addv(messagePanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->messagePanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
@@ -547,7 +547,7 @@ void wmm_createQuitMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(20, 25)));
+        vec2_addv(messagePanel, vec2i(20, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleQuitQuit);
     setUIButtonHotKey(uiEntity, WAR_KEY_Q);
@@ -559,7 +559,7 @@ void wmm_createQuitMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(115, 25)));
+        vec2_addv(messagePanel, vec2i(115, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleQuitMenu);
     setUIButtonHotKey(uiEntity, WAR_KEY_M);
@@ -571,7 +571,7 @@ void wmm_createQuitMenu(WarContext* context)
         smallNormalRef,
         smallPressedRef,
         invalidRef,
-        vec2Addv(messagePanel, vec2i(210, 25)));
+        vec2_addv(messagePanel, vec2i(210, 25)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleQuitCancel);
     setUIButtonHotKey(uiEntity, WAR_KEY_C);
@@ -582,7 +582,7 @@ void createDemoEndMenu(WarContext* context)
 {
     WarMap* map = context->map;
 
-    vec2 menuPanel = rectTopLeft(map->menuPanel);
+    vec2 menuPanel = RECT_TOP_LEFT(map->menuPanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef mediumNormalRef = imageResourceRef(239);
@@ -594,7 +594,7 @@ void createDemoEndMenu(WarContext* context)
         context, wstr_fromCString("txtDemoEndHeader"),
         1, 10,
         wstr_fromCString("Thanks for playing!"),
-        vec2Addv(menuPanel, vec2i(0, 10)));
+        vec2_addv(menuPanel, vec2i(0, 10)));
     setUIEntityStatus(uiEntity, false);
     setUITextBoundings(uiEntity, vec2f(map->menuPanel.width, 12));
     setUITextHorizontalAlign(uiEntity, WAR_TEXT_ALIGN_CENTER);
@@ -613,7 +613,7 @@ void createDemoEndMenu(WarContext* context)
         "of Blizzard Entertainment.\n"
         "\n"
         "Made by @acoto87"),
-        vec2Addv(menuPanel, vec2i(8, 26)));
+        vec2_addv(menuPanel, vec2i(8, 26)));
     setUIEntityStatus(uiEntity, false);
     setUITextMultiline(uiEntity, true);
     setUITextBoundings(uiEntity, vec2f(map->menuPanel.width - 16, 75));
@@ -628,7 +628,7 @@ void createDemoEndMenu(WarContext* context)
         mediumNormalRef,
         mediumPressedRef,
         invalidRef,
-        vec2Addv(menuPanel, vec2i(20, 105)));
+        vec2_addv(menuPanel, vec2i(20, 105)));
     setUIEntityStatus(uiEntity, false);
     setUIButtonClickHandler(uiEntity, wmm_handleDemoEndMenu);
     setUIButtonHotKey(uiEntity, WAR_KEY_M);
@@ -901,7 +901,7 @@ void wmm_handleMusicVolDec(WarContext* context, WarEntity* entity)
 
     WarMap* map = context->map;
 
-    map->settings2.musicVol = clamp(map->settings2.musicVol - 5, 0, 100);
+    map->settings2.musicVol = CLAMP(map->settings2.musicVol - 5, 0, 100);
     setUITextS32ValueByName(context, wsv_fromCString("txtOptionsMusicVolValue"), map->settings2.musicVol);
 }
 
@@ -911,7 +911,7 @@ void wmm_handleMusicVolInc(WarContext* context, WarEntity* entity)
 
     WarMap* map = context->map;
 
-    map->settings2.musicVol = clamp(map->settings2.musicVol + 5, 0, 100);
+    map->settings2.musicVol = CLAMP(map->settings2.musicVol + 5, 0, 100);
     setUITextS32ValueByName(context, wsv_fromCString("txtOptionsMusicVolValue"), map->settings2.musicVol);
 }
 
@@ -921,7 +921,7 @@ void wmm_handleSfxVolDec(WarContext* context, WarEntity* entity)
 
     WarMap* map = context->map;
 
-    map->settings2.sfxVol = clamp(map->settings2.sfxVol - 5, 0, 100);
+    map->settings2.sfxVol = CLAMP(map->settings2.sfxVol - 5, 0, 100);
     setUITextS32ValueByName(context, wsv_fromCString("txtOptionsSFXVolValue"), map->settings2.sfxVol);
 }
 
@@ -931,7 +931,7 @@ void wmm_handleSfxVolInc(WarContext* context, WarEntity* entity)
 
     WarMap* map = context->map;
 
-    map->settings2.sfxVol = clamp(map->settings2.sfxVol + 5, 0, 100);
+    map->settings2.sfxVol = CLAMP(map->settings2.sfxVol + 5, 0, 100);
     setUITextS32ValueByName(context, wsv_fromCString("txtOptionsSFXVolValue"), map->settings2.sfxVol);
 }
 

--- a/src/war_map_ui.c
+++ b/src/war_map_ui.c
@@ -12,12 +12,12 @@ void wmui_createMapUI(WarContext* context)
     WarMap* map = context->map;
     WarPlayerInfo* player = &map->players[0];
 
-    vec2 leftTopPanel = rectTopLeft(map->leftTopPanel);
-    vec2 leftBottomPanel = rectTopLeft(map->leftBottomPanel);
-    vec2 topPanel = rectTopLeft(map->topPanel);
-    vec2 rightPanel = rectTopLeft(map->rightPanel);
-    vec2 bottomPanel = rectTopLeft(map->bottomPanel);
-    vec2 minimapPanel = rectTopLeft(map->minimapPanel);
+    vec2 leftTopPanel = RECT_TOP_LEFT(map->leftTopPanel);
+    vec2 leftBottomPanel = RECT_TOP_LEFT(map->leftBottomPanel);
+    vec2 topPanel = RECT_TOP_LEFT(map->topPanel);
+    vec2 rightPanel = RECT_TOP_LEFT(map->rightPanel);
+    vec2 bottomPanel = RECT_TOP_LEFT(map->bottomPanel);
+    vec2 minimapPanel = RECT_TOP_LEFT(map->minimapPanel);
 
     WarSpriteResourceRef invalidRef = invalidResourceRef();
     WarSpriteResourceRef normalRef = imageResourceRef(364);
@@ -43,86 +43,86 @@ void wmui_createMapUI(WarContext* context)
     wmui_createUIMinimap(context, wstr_fromCString("minimap"), minimapPanel);
 
     // top panel images
-    wui_createUIImage(context, wstr_fromCString("imgGold"), imageResourceRef(406), vec2Addv(topPanel, vec2i(201, 1)));
-    wui_createUIImage(context, wstr_fromCString("imgLumber"), imageResourceRef(407), vec2Addv(topPanel, vec2i(102, 0)));
+    wui_createUIImage(context, wstr_fromCString("imgGold"), imageResourceRef(406), vec2_addv(topPanel, vec2i(201, 1)));
+    wui_createUIImage(context, wstr_fromCString("imgLumber"), imageResourceRef(407), vec2_addv(topPanel, vec2i(102, 0)));
 
     // top panel texts
-    wui_createUIText(context, wstr_fromCString("txtGold"), 0, 6, wstr_make(), vec2Addv(topPanel, vec2i(135, 2)));
-    wui_createUIText(context, wstr_fromCString("txtWood"), 0, 6, wstr_make(), vec2Addv(topPanel, vec2i(24, 2)));
+    wui_createUIText(context, wstr_fromCString("txtGold"), 0, 6, wstr_make(), vec2_addv(topPanel, vec2i(135, 2)));
+    wui_createUIText(context, wstr_fromCString("txtWood"), 0, 6, wstr_make(), vec2_addv(topPanel, vec2i(24, 2)));
 
     // status text
-    wui_createUIText(context, wstr_fromCString("txtStatus"), 0, 6, wstr_make(), vec2Addv(bottomPanel, vec2i(2, 5)));
-    wui_createUIImage(context, wstr_fromCString("imgStatusWood"), imageResourceRef(407), vec2Addv(bottomPanel, vec2i(163, 3)));
-    wui_createUIImage(context, wstr_fromCString("imgStatusGold"), imageResourceRef(406), vec2Addv(bottomPanel, vec2i(200, 5)));
-    wui_createUIText(context, wstr_fromCString("txtStatusWood"), 0, 6, wstr_make(), vec2Addv(bottomPanel, vec2i(179, 5)));
-    wui_createUIText(context, wstr_fromCString("txtStatusGold"), 0, 6, wstr_make(), vec2Addv(bottomPanel, vec2i(218, 5)));
-    wui_createUIRect(context, wstr_fromCString("txtStatusCursor"), vec2Addv(bottomPanel, vec2i(2, 4)), vec2i(1, 7), WAR_COLOR_WHITE);
+    wui_createUIText(context, wstr_fromCString("txtStatus"), 0, 6, wstr_make(), vec2_addv(bottomPanel, vec2i(2, 5)));
+    wui_createUIImage(context, wstr_fromCString("imgStatusWood"), imageResourceRef(407), vec2_addv(bottomPanel, vec2i(163, 3)));
+    wui_createUIImage(context, wstr_fromCString("imgStatusGold"), imageResourceRef(406), vec2_addv(bottomPanel, vec2i(200, 5)));
+    wui_createUIText(context, wstr_fromCString("txtStatusWood"), 0, 6, wstr_make(), vec2_addv(bottomPanel, vec2i(179, 5)));
+    wui_createUIText(context, wstr_fromCString("txtStatusGold"), 0, 6, wstr_make(), vec2_addv(bottomPanel, vec2i(218, 5)));
+    wui_createUIRect(context, wstr_fromCString("txtStatusCursor"), vec2_addv(bottomPanel, vec2i(2, 4)), vec2i(1, 7), WAR_COLOR_WHITE);
 
-    uiEntity = wui_createUIText(context, wstr_fromCString("txtCheatFeedbackText"), 1, 8, wstr_make(), vec2Addv(bottomPanel, vec2i(15, -20)));
+    uiEntity = wui_createUIText(context, wstr_fromCString("txtCheatFeedbackText"), 1, 8, wstr_make(), vec2_addv(bottomPanel, vec2i(15, -20)));
     setUITextColor(uiEntity, WAR_COLOR_YELLOW);
     setUIEntityStatus(uiEntity, false);
 
     // selected unit(s) info
-    wui_createUIImage(context, wstr_fromCString("imgUnitInfo"), imageResourceRefFromPlayer(player, 360, 359), vec2Addv(leftBottomPanel, vec2i(2, 0)));
-    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait0"), portraitsRef, vec2Addv(leftBottomPanel, vec2i(6, 4)));
-    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait1"), portraitsRef, vec2Addv(leftBottomPanel, vec2i(4, 1)));
-    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait2"), portraitsRef, vec2Addv(leftBottomPanel, vec2i(38, 1)));
-    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait3"), portraitsRef, vec2Addv(leftBottomPanel, vec2i(4, 23)));
-    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait4"), portraitsRef, vec2Addv(leftBottomPanel, vec2i(38, 23)));
-    wui_createUIImage(context, wstr_fromCString("imgUnitInfoLife"), imageResourceRefFromPlayer(player, 360, 359), vec2Addv(leftBottomPanel, vec2i(3, 16)));
-    wui_createUIText(context, wstr_fromCString("txtUnitName"), 0, 6, wstr_make(), vec2Addv(leftBottomPanel, vec2i(6, 26)));
-    wui_createUIRect(context, wstr_fromCString("rectLifeBar0"), vec2Addv(leftBottomPanel, vec2i(37, 20)), vec2i(27, 3), WAR_COLOR_GREEN);
-    wui_createUIRect(context, wstr_fromCString("rectLifeBar1"), vec2Addv(leftBottomPanel, vec2i(4, 17)), vec2i(27, 3), WAR_COLOR_GREEN);
-    wui_createUIRect(context, wstr_fromCString("rectLifeBar2"), vec2Addv(leftBottomPanel, vec2i(38, 17)), vec2i(27, 3), WAR_COLOR_GREEN);
-    wui_createUIRect(context, wstr_fromCString("rectLifeBar3"), vec2Addv(leftBottomPanel, vec2i(4, 39)), vec2i(27, 3), WAR_COLOR_GREEN);
-    wui_createUIRect(context, wstr_fromCString("rectLifeBar4"), vec2Addv(leftBottomPanel, vec2i(38, 39)), vec2i(27, 3), WAR_COLOR_GREEN);
-    wui_createUIRect(context, wstr_fromCString("rectMagicBar"), vec2Addv(leftBottomPanel, vec2i(37, 9)), vec2i(27, 3), WAR_COLOR_GREEN);
-    wui_createUIRect(context, wstr_fromCString("rectPercentBar"), vec2Addv(leftBottomPanel, vec2i(4, 37)), vec2i(62, 5), WAR_COLOR_GREEN);
-    wui_createUIImage(context, wstr_fromCString("rectPercentText"), imageResourceRef(410), vec2Addv(leftBottomPanel, vec2i(15, 37)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitInfo"), imageResourceRefFromPlayer(player, 360, 359), vec2_addv(leftBottomPanel, vec2i(2, 0)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait0"), portraitsRef, vec2_addv(leftBottomPanel, vec2i(6, 4)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait1"), portraitsRef, vec2_addv(leftBottomPanel, vec2i(4, 1)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait2"), portraitsRef, vec2_addv(leftBottomPanel, vec2i(38, 1)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait3"), portraitsRef, vec2_addv(leftBottomPanel, vec2i(4, 23)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitPortrait4"), portraitsRef, vec2_addv(leftBottomPanel, vec2i(38, 23)));
+    wui_createUIImage(context, wstr_fromCString("imgUnitInfoLife"), imageResourceRefFromPlayer(player, 360, 359), vec2_addv(leftBottomPanel, vec2i(3, 16)));
+    wui_createUIText(context, wstr_fromCString("txtUnitName"), 0, 6, wstr_make(), vec2_addv(leftBottomPanel, vec2i(6, 26)));
+    wui_createUIRect(context, wstr_fromCString("rectLifeBar0"), vec2_addv(leftBottomPanel, vec2i(37, 20)), vec2i(27, 3), WAR_COLOR_GREEN);
+    wui_createUIRect(context, wstr_fromCString("rectLifeBar1"), vec2_addv(leftBottomPanel, vec2i(4, 17)), vec2i(27, 3), WAR_COLOR_GREEN);
+    wui_createUIRect(context, wstr_fromCString("rectLifeBar2"), vec2_addv(leftBottomPanel, vec2i(38, 17)), vec2i(27, 3), WAR_COLOR_GREEN);
+    wui_createUIRect(context, wstr_fromCString("rectLifeBar3"), vec2_addv(leftBottomPanel, vec2i(4, 39)), vec2i(27, 3), WAR_COLOR_GREEN);
+    wui_createUIRect(context, wstr_fromCString("rectLifeBar4"), vec2_addv(leftBottomPanel, vec2i(38, 39)), vec2i(27, 3), WAR_COLOR_GREEN);
+    wui_createUIRect(context, wstr_fromCString("rectMagicBar"), vec2_addv(leftBottomPanel, vec2i(37, 9)), vec2i(27, 3), WAR_COLOR_GREEN);
+    wui_createUIRect(context, wstr_fromCString("rectPercentBar"), vec2_addv(leftBottomPanel, vec2i(4, 37)), vec2i(62, 5), WAR_COLOR_GREEN);
+    wui_createUIImage(context, wstr_fromCString("rectPercentText"), imageResourceRef(410), vec2_addv(leftBottomPanel, vec2i(15, 37)));
 
     // texts in the command area
-    wui_createUIText(context, wstr_fromCString("txtCommand0"), 0, 6, wstr_make(), vec2Addv(leftBottomPanel, vec2i(3, 46)));
-    wui_createUIText(context, wstr_fromCString("txtCommand1"), 0, 6, wstr_make(), vec2Addv(leftBottomPanel, vec2i(3, 56)));
-    wui_createUIText(context, wstr_fromCString("txtCommand2"), 0, 6, wstr_make(), vec2Addv(leftBottomPanel, vec2i(7, 64)));
-    wui_createUIText(context, wstr_fromCString("txtCommand3"), 0, 6, wstr_make(), vec2Addv(leftBottomPanel, vec2i(11, 54)));
+    wui_createUIText(context, wstr_fromCString("txtCommand0"), 0, 6, wstr_make(), vec2_addv(leftBottomPanel, vec2i(3, 46)));
+    wui_createUIText(context, wstr_fromCString("txtCommand1"), 0, 6, wstr_make(), vec2_addv(leftBottomPanel, vec2i(3, 56)));
+    wui_createUIText(context, wstr_fromCString("txtCommand2"), 0, 6, wstr_make(), vec2_addv(leftBottomPanel, vec2i(7, 64)));
+    wui_createUIText(context, wstr_fromCString("txtCommand3"), 0, 6, wstr_make(), vec2_addv(leftBottomPanel, vec2i(11, 54)));
 
     // command buttons
     wui_createUIImageButton(
         context, wstr_fromCString("btnCommand0"),
         normalRef, pressedRef, portraitsRef,
-        vec2Addv(leftBottomPanel, vec2i(2, 44)));
+        vec2_addv(leftBottomPanel, vec2i(2, 44)));
 
     wui_createUIImageButton(
         context, wstr_fromCString("btnCommand1"),
         normalRef, pressedRef, portraitsRef,
-        vec2Addv(leftBottomPanel, vec2i(36, 44)));
+        vec2_addv(leftBottomPanel, vec2i(36, 44)));
 
     wui_createUIImageButton(
         context, wstr_fromCString("btnCommand2"),
         normalRef, pressedRef, portraitsRef,
-        vec2Addv(leftBottomPanel, vec2i(2, 67)));
+        vec2_addv(leftBottomPanel, vec2i(2, 67)));
 
     wui_createUIImageButton(
         context, wstr_fromCString("btnCommand3"),
         normalRef, pressedRef, portraitsRef,
-        vec2Addv(leftBottomPanel, vec2i(36, 67)));
+        vec2_addv(leftBottomPanel, vec2i(36, 67)));
 
     wui_createUIImageButton(
         context, wstr_fromCString("btnCommand4"),
         normalRef, pressedRef, portraitsRef,
-        vec2Addv(leftBottomPanel, vec2i(2, 90)));
+        vec2_addv(leftBottomPanel, vec2i(2, 90)));
 
     wui_createUIImageButton(
         context, wstr_fromCString("btnCommand5"),
         normalRef, pressedRef, portraitsRef,
-        vec2Addv(leftBottomPanel, vec2i(36, 90)));
+        vec2_addv(leftBottomPanel, vec2i(36, 90)));
 
     uiEntity = wui_createUIImageButton(
         context, wstr_fromCString("btnMenu"),
         imageResourceRef(362),
         imageResourceRef(363),
         invalidRef,
-        vec2Addv(leftBottomPanel, vec2i(3, 116)));
+        vec2_addv(leftBottomPanel, vec2i(3, 116)));
     wui_setUITooltip(uiEntity, 6, 3, wstr_fromCString("MENU (F10)"));
     setUIButtonClickHandler(uiEntity, wmm_handleMenu);
     setUIButtonHotKey(uiEntity, WAR_KEY_F10);
@@ -219,7 +219,7 @@ void wmui_updateSelectedUnitsInfo(WarContext* context)
     //
     // TODO: the max number of selected entities shouldn't greater than 4 but
     // that's not implemented right now, so put a min call to guard for that.
-    s32 selectedEntitiesCount = min(map->selectedEntities.count, 4);
+    s32 selectedEntitiesCount = MIN(map->selectedEntities.count, 4);
     if (selectedEntitiesCount > 1)
     {
         // for 4 units selected -> frame indices 5, 8
@@ -343,7 +343,7 @@ void wmui_setLifeBar(WarEntity* rectLifeBar, WarUnitComponent* unit)
 #define LIFE_BAR_YELLOW_THRESHOLD 0.70f
 #define LIFE_BAR_WIDTH_PX 27
 
-    f32 hpPercent = percentabf01(unit->hp, unit->maxhp);
+    f32 hpPercent = PERCENTF01(unit->hp, unit->maxhp);
 
     if (hpPercent <= LIFE_BAR_RED_THRESHOLD)
         rectLifeBar->rect.color = WAR_COLOR_RED;
@@ -359,7 +359,7 @@ void wmui_setManaBar(WarEntity* rectMagicBar, WarUnitComponent* unit)
 {
 #define MAGIC_BAR_WIDTH_PX 27
 
-    f32 magicPercent = percentabf01(unit->mana, unit->maxMana);
+    f32 magicPercent = PERCENTF01(unit->mana, unit->maxMana);
     wui_setUIRectWidth(rectMagicBar, (s32)(magicPercent * MAGIC_BAR_WIDTH_PX));
 }
 

--- a/src/war_math.c
+++ b/src/war_math.c
@@ -12,157 +12,157 @@ vec2 vec2i(s32 x, s32 y)
     return (vec2){(f32)x, (f32)y};
 }
 
-vec2 vec2Addv(vec2 a, vec2 b)
+vec2 vec2_addv(vec2 a, vec2 b)
 {
     return (vec2){a.x + b.x, a.y + b.y};
 }
 
-vec2 vec2Addi(vec2 v, s32 x)
+vec2 vec2_addi(vec2 v, s32 x)
 {
     return (vec2){v.x + x, v.y + x};
 }
 
-vec2 vec2Addf(vec2 v, f32 x)
+vec2 vec2_addf(vec2 v, f32 x)
 {
     return (vec2){v.x + x, v.y + x};
 }
 
-vec2 vec2Subv(vec2 a, vec2 b)
+vec2 vec2_subv(vec2 a, vec2 b)
 {
     return (vec2){a.x - b.x, a.y - b.y};
 }
 
-vec2 vec2Subi(vec2 v, s32 x)
+vec2 vec2_subi(vec2 v, s32 x)
 {
     return (vec2){v.x - x, v.y - x};
 }
 
-vec2 vec2Subf(vec2 v, f32 x)
+vec2 vec2_subf(vec2 v, f32 x)
 {
     return (vec2){v.x - x, v.y - x};
 }
 
-vec2 vec2Mulf(vec2 v, f32 a)
+vec2 vec2_mulf(vec2 v, f32 a)
 {
     return (vec2){v.x * a, v.y * a};
 }
 
-vec2 vec2Muli(vec2 v, s32 a)
+vec2 vec2_muli(vec2 v, s32 a)
 {
     return (vec2){v.x * (f32)a, v.y * (f32)a};
 }
 
-vec2 vec2Mulv(vec2 a, vec2 b)
+vec2 vec2_mulv(vec2 a, vec2 b)
 {
     return (vec2){a.x * b.x, a.y * b.y};
 }
 
-vec2 vec2Half(vec2 a)
+vec2 vec2_half(vec2 a)
 {
     return (vec2){a.x * 0.5f, a.y * 0.5f};
 }
 
-vec2 vec2Translatef(vec2 v, f32 x, f32 y)
+vec2 vec2_translatef(vec2 v, f32 x, f32 y)
 {
     return (vec2){v.x + x, v.y + y};
 }
 
-vec2 vec2Translatei(vec2 v, s32 x, s32 y)
+vec2 vec2_translatei(vec2 v, s32 x, s32 y)
 {
     return (vec2){v.x + (f32)x, v.y + (f32)y};
 }
 
-vec2 vec2Scalef(vec2 v, f32 scale)
+vec2 vec2_scalef(vec2 v, f32 scale)
 {
     return (vec2){v.x * scale, v.y * scale};
 }
 
-vec2 vec2Scalei(vec2 v, s32 scale)
+vec2 vec2_scalei(vec2 v, s32 scale)
 {
     return (vec2){v.x * (f32)scale, v.y * (f32)scale};
 }
 
-vec2 vec2Scalev(vec2 v, vec2 scale)
+vec2 vec2_scalev(vec2 v, vec2 scale)
 {
     return (vec2){v.x * scale.x, v.y * scale.y};
 }
 
-vec2 vec2Inverse(vec2 v)
+vec2 vec2_inverse(vec2 v)
 {
     return (vec2){-v.x, -v.y};
 }
 
-f32 vec2LengthSqr(vec2 v)
+f32 vec2_lengthSqr(vec2 v)
 {
     return v.x * v.x + v.y * v.y;
 }
 
-f32 vec2Length(vec2 v)
+f32 vec2_length(vec2 v)
 {
-    return sqrtf(vec2LengthSqr(v));
+    return sqrtf(vec2_lengthSqr(v));
 }
 
-f32 vec2DistanceSqr(vec2 v1, vec2 v2)
+f32 vec2_distanceSqr(vec2 v1, vec2 v2)
 {
     f32 xx = (v1.x - v2.x);
     f32 yy = (v1.y - v2.y);
     return xx * xx + yy * yy;
 }
 
-f32 vec2Distance(vec2 v1, vec2 v2)
+f32 vec2_distance(vec2 v1, vec2 v2)
 {
-    return sqrtf(vec2DistanceSqr(v1, v2));
+    return sqrtf(vec2_distanceSqr(v1, v2));
 }
 
-f32 vec2DistanceInTiles(vec2 v1, vec2 v2)
+f32 vec2_distanceInTiles(vec2 v1, vec2 v2)
 {
-    vec2 diff = vec2Subv(v1, v2);
-    return max(abs(diff.x), abs(diff.y));
+    vec2 diff = vec2_subv(v1, v2);
+    return MAX(ABS(diff.x), ABS(diff.y));
 }
 
-vec2 vec2Normalize(vec2 v)
+vec2 vec2_normalize(vec2 v)
 {
-    f32 len = vec2Length(v);
-    return len != 0 ? vec2Scalef(v, 1 / len) : VEC2_ZERO;
+    f32 len = vec2_length(v);
+    return len != 0 ? vec2_scalef(v, 1 / len) : VEC2_ZERO;
 }
 
-f32 vec2Dot(vec2 v1, vec2 v2)
+f32 vec2_dot(vec2 v1, vec2 v2)
 {
     return v1.x * v2.x + v1.y * v2.y;
 }
 
-f32 vec2Determinant(vec2 v1, vec2 v2)
+f32 vec2_determinant(vec2 v1, vec2 v2)
 {
     return v1.x * v2.x - v1.y * v2.y;
 }
 
-s32 vec2Orientation(vec2 v1, vec2 v2)
+s32 vec2_orientation(vec2 v1, vec2 v2)
 {
     return v1.x * v2.y - v1.y * v2.x >= 0 ? 1 : -1;
 }
 
-f32 vec2Angle(vec2 v1, vec2 v2)
+f32 vec2_angle(vec2 v1, vec2 v2)
 {
-    f32 v1Length = vec2Length(v1);
-    f32 v2Length = vec2Length(v2);
+    f32 v1Length = vec2_length(v1);
+    f32 v2Length = vec2_length(v2);
     if (v1Length == 0 || v2Length == 0)
         return 0;
 
-    f32 dot = vec2Dot(v1, v2);
+    f32 dot = vec2_dot(v1, v2);
     f32 angleRad = acosf(dot / (v1Length * v2Length));
-    return rad2Deg(angleRad);
+    return RAD2DEG(angleRad);
 }
 
-f32 vec2ClockwiseAngle(vec2 v1, vec2 v2)
+f32 vec2_angleClockwise(vec2 v1, vec2 v2)
 {
-    f32 v1Length = vec2Length(v1);
-    f32 v2Length = vec2Length(v2);
+    f32 v1Length = vec2_length(v1);
+    f32 v2Length = vec2_length(v2);
     if (v1Length == 0 || v2Length == 0)
         return 0;
 
-    s32 orientation = vec2Orientation(v1, v2);
+    s32 orientation = vec2_orientation(v1, v2);
 
-    f32 dot = vec2Dot(v1, v2);
+    f32 dot = vec2_dot(v1, v2);
     f32 angleRad = acosf(dot / (v1Length * v2Length));
 
     // if the two vectors are in counter-clockwise orientation
@@ -170,40 +170,40 @@ f32 vec2ClockwiseAngle(vec2 v1, vec2 v2)
     if (orientation < 0)
         angleRad = 2 * PI - angleRad;
 
-    return rad2Deg(angleRad);
+    return RAD2DEG(angleRad);
 }
 
-vec2 vec2Clampf(vec2 v, f32 a, f32 b)
+vec2 vec2_clampf(vec2 v, f32 a, f32 b)
 {
-    return (vec2){clamp(v.x, a, b), clamp(v.y, a, b)};
+    return (vec2){CLAMP(v.x, a, b), CLAMP(v.y, a, b)};
 }
 
-vec2 vec2Clampi(vec2 v, s32 a, s32 b)
+vec2 vec2_clampi(vec2 v, s32 a, s32 b)
 {
-    return (vec2){clamp(v.x, (f32)a, (f32)b), clamp(v.y, (f32)a, (f32)b)};
+    return (vec2){CLAMP(v.x, (f32)a, (f32)b), CLAMP(v.y, (f32)a, (f32)b)};
 }
 
-vec2 vec2Clampv(vec2 v, vec2 a, vec2 b)
+vec2 vec2_clampv(vec2 v, vec2 a, vec2 b)
 {
-    return (vec2){clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y)};
+    return (vec2){CLAMP(v.x, a.x, b.x), CLAMP(v.y, a.y, b.y)};
 }
 
-vec2 vec2Floor(vec2 v)
+vec2 vec2_floor(vec2 v)
 {
     return (vec2){floorf(v.x), floorf(v.y)};
 }
 
-vec2 vec2Ceil(vec2 v)
+vec2 vec2_ceil(vec2 v)
 {
     return (vec2){ceilf(v.x), ceilf(v.y)};
 }
 
-vec2 vec2Round(vec2 v)
+vec2 vec2_round(vec2 v)
 {
     return (vec2){roundf(v.x), roundf(v.y)};
 }
 
-void vec2Print(vec2 v)
+void vec2_print(vec2 v)
 {
     logDebug("(%f, %f)", v.x, v.y);
 }
@@ -220,7 +220,7 @@ rect recti(s32 x, s32 y, s32 width, s32 height)
 
 rect rectpf(f32 x1, f32 y1, f32 x2, f32 y2)
 {
-    return rectf(min(x1, x2), min(y1, y2), abs(x1 - x2), abs(y1 - y2));
+    return rectf(MIN(x1, x2), MIN(y1, y2), ABS(x1 - x2), ABS(y1 - y2));
 }
 
 rect rectv(vec2 pos, vec2 size)
@@ -233,19 +233,19 @@ rect rects(vec2 size)
     return (rect){0.0f, 0.0f, size.x, size.y};
 }
 
-bool rectContainsf(rect r, f32 x, f32 y)
+bool rect_containsf(rect r, f32 x, f32 y)
 {
     return x >= r.x && x <= r.x + r.width &&
            y >= r.y && y <= r.y + r.height;
 }
 
-bool rectIntersects(rect r1, rect r2)
+bool rect_intersects(rect r1, rect r2)
 {
     return !(r1.x + r1.width < r2.x || r1.x > r2.x + r2.width ||
              r1.y + r1.height < r2.y || r1.y > r2.y + r2.height);
 }
 
-rect rectScalef(rect r, f32 scale)
+rect rect_scalef(rect r, f32 scale)
 {
     r.x *= scale;
     r.y *= scale;
@@ -254,19 +254,19 @@ rect rectScalef(rect r, f32 scale)
     return r;
 }
 
-rect rectTranslatef(rect r, f32 x, f32 y)
+rect rect_translatef(rect r, f32 x, f32 y)
 {
     r.x += x;
     r.y += y;
     return r;
 }
 
-vec2 rectCenter(rect r)
+vec2 rect_center(rect r)
 {
-    return vec2f(r.x + halff(r.width), r.y + halff(r.height));
+    return vec2f(r.x + 0.5f * r.width, r.y + 0.5f * r.height);
 }
 
-rect rectExpand(rect r, f32 dx, f32 dy)
+rect rect_expand(rect r, f32 dx, f32 dy)
 {
     r.x -= dx;
     r.y -= dy;
@@ -275,7 +275,7 @@ rect rectExpand(rect r, f32 dx, f32 dy)
     return r;
 }
 
-vec2 getClosestPointOnRect(vec2 p, rect r)
+vec2 get_closestPointOnRect(vec2 p, rect r)
 {
     f32 left = r.x;
     f32 top = r.y;
@@ -318,31 +318,31 @@ vec2 getClosestPointOnRect(vec2 p, rect r)
     return p;
 }
 
-void rectPrint(rect r)
+void rect_print(rect r)
 {
     logDebug("(%f, %f, %f, %f)", r.x, r.y, r.width, r.height);
 }
 
-bool wt_equalsS32(const s32 a, const s32 b)
+bool equalsS32(const s32 a, const s32 b)
 {
     return a == b;
 }
 
-bool wt_compareS32(const s32 a, const s32 b)
+bool compareS32(const s32 a, const s32 b)
 {
     return a - b;
 }
 
 shlDefineList(s32List, s32)
 
-bool wt_equalsVec2(const vec2 v1, const vec2 v2)
+bool equalsVec2(const vec2 v1, const vec2 v2)
 {
     return v1.x == v2.x && v1.y == v2.y;
 }
 
 shlDefineList(vec2List, vec2)
 
-bool wt_equalsRect(const rect r1, const rect r2)
+bool equalsRect(const rect r1, const rect r2)
 {
     return r1.x == r2.x && r1.y == r2.y &&
            r1.width == r2.width && r1.height == r2.height;

--- a/src/war_math.h
+++ b/src/war_math.h
@@ -4,33 +4,22 @@
 
 #include "common.h"
 
-#ifdef min
-#undef min
-#endif
+#define SIGN(x) ((x) < 0 ? -1 : 1)
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define CLAMP(x, a, b) (MAX(MIN(x, b), a))
+#define ABS(x) ((x) < 0 ? -(x) : (x))
 
-#ifdef max
-#undef max
-#endif
-
-#define sign(x) ((x) < 0 ? -1 : 1)
-#define min(a, b) ((a) < (b) ? (a) : (b))
-#define max(a, b) ((a) > (b) ? (a) : (b))
-#define clamp(x, a, b) (max(min(x, b), a))
-#define abs(x) ((x) < 0 ? -(x) : (x))
-
-#define halfi(x) ((x) / 2)
-#define halff(x) ((x) * 0.5f)
-
-#define percentf(x) ((x) * 100)
-#define percenti(x) ((s32)percentf(x))
-#define percentabf01(a, b) ((f32)(a)/(b))
-#define percentabf(a, b) percentf(percentabf01(a, b))
-#define percentabi(a, b) percenti(percentabf01(a, b))
+#define PERCENTF(x) ((x) * 100)
+#define PERCENTI(x) ((s32)PERCENTF(x))
+#define PERCENTF01(a, b) ((f32)(a)/(b))
+#define PERCENTABF(a, b) PERCENTF(PERCENTF01(a, b))
+#define PERCENTABI(a, b) PERCENTI(PERCENTF01(a, b))
 
 #define PI 3.14159265358979323846264338327f
 
-#define rad2Deg(x) ((x) * 180 / PI)
-#define deg2Rad(x) ((x) * PI / 180)
+#define RAD2DEG(x) ((x) * 180 / PI)
+#define DEG2RAD(x) ((x) * PI / 180)
 
 /*
  * vec2 types and functions
@@ -47,45 +36,45 @@ typedef struct
 #define VEC2_RIGHT ((vec2){1.0f, 0.0f})
 #define VEC2_DOWN ((vec2){0.0f, 1.0f})
 
-#define vec2IsZero(v) ((v).x == 0.0f && (v).y == 0.0f)
-#define vec2IsOne(v) ((v).x == 1.0f && (v).y == 1.0f)
+#define VEC2_IS_ZERO(v) ((v).x == 0.0f && (v).y == 0.0f)
+#define VEC2_IS_ONE(v) ((v).x == 1.0f && (v).y == 1.0f)
 
 vec2 vec2f(f32 x, f32 y);
 vec2 vec2i(s32 x, s32 y);
-vec2 vec2Addv(vec2 a, vec2 b);
-vec2 vec2Addi(vec2 v, s32 x);
-vec2 vec2Addf(vec2 v, f32 x);
-vec2 vec2Subv(vec2 a, vec2 b);
-vec2 vec2Subi(vec2 v, s32 x);
-vec2 vec2Subf(vec2 v, f32 x);
-vec2 vec2Mulf(vec2 v, f32 a);
-vec2 vec2Muli(vec2 v, s32 a);
-vec2 vec2Mulv(vec2 a, vec2 b);
-vec2 vec2Half(vec2 a);
-vec2 vec2Translatef(vec2 v, f32 x, f32 y);
-vec2 vec2Translatei(vec2 v, s32 x, s32 y);
-vec2 vec2Scalef(vec2 v, f32 scale);
-vec2 vec2Scalei(vec2 v, s32 scale);
-vec2 vec2Scalev(vec2 v, vec2 scale);
-vec2 vec2Inverse(vec2 v);
-f32 vec2LengthSqr(vec2 v);
-f32 vec2Length(vec2 v);
-f32 vec2DistanceSqr(vec2 v1, vec2 v2);
-f32 vec2Distance(vec2 v1, vec2 v2);
-f32 vec2DistanceInTiles(vec2 v1, vec2 v2);
-vec2 vec2Normalize(vec2 v);
-f32 vec2Dot(vec2 v1, vec2 v2);
-f32 vec2Determinant(vec2 v1, vec2 v2);
-s32 vec2Orientation(vec2 v1, vec2 v2);
-f32 vec2Angle(vec2 v1, vec2 v2);
-f32 vec2ClockwiseAngle(vec2 v1, vec2 v2);
-vec2 vec2Clampf(vec2 v, f32 a, f32 b);
-vec2 vec2Clampi(vec2 v, s32 a, s32 b);
-vec2 vec2Clampv(vec2 v, vec2 a, vec2 b);
-vec2 vec2Floor(vec2 v);
-vec2 vec2Ceil(vec2 v);
-vec2 vec2Round(vec2 v);
-void vec2Print(vec2 v);
+vec2 vec2_addv(vec2 a, vec2 b);
+vec2 vec2_addi(vec2 v, s32 x);
+vec2 vec2_addf(vec2 v, f32 x);
+vec2 vec2_subv(vec2 a, vec2 b);
+vec2 vec2_subi(vec2 v, s32 x);
+vec2 vec2_subf(vec2 v, f32 x);
+vec2 vec2_mulf(vec2 v, f32 a);
+vec2 vec2_muli(vec2 v, s32 a);
+vec2 vec2_mulv(vec2 a, vec2 b);
+vec2 vec2_half(vec2 a);
+vec2 vec2_translatef(vec2 v, f32 x, f32 y);
+vec2 vec2_translatei(vec2 v, s32 x, s32 y);
+vec2 vec2_scalef(vec2 v, f32 scale);
+vec2 vec2_scalei(vec2 v, s32 scale);
+vec2 vec2_scalev(vec2 v, vec2 scale);
+vec2 vec2_inverse(vec2 v);
+f32 vec2_lengthSqr(vec2 v);
+f32 vec2_length(vec2 v);
+f32 vec2_distanceSqr(vec2 v1, vec2 v2);
+f32 vec2_distance(vec2 v1, vec2 v2);
+f32 vec2_distanceInTiles(vec2 v1, vec2 v2);
+vec2 vec2_normalize(vec2 v);
+f32 vec2_dot(vec2 v1, vec2 v2);
+f32 vec2_determinant(vec2 v1, vec2 v2);
+s32 vec2_orientation(vec2 v1, vec2 v2);
+f32 vec2_angle(vec2 v1, vec2 v2);
+f32 vec2_angleClockwise(vec2 v1, vec2 v2);
+vec2 vec2_clampf(vec2 v, f32 a, f32 b);
+vec2 vec2_clampi(vec2 v, s32 a, s32 b);
+vec2 vec2_clampv(vec2 v, vec2 a, vec2 b);
+vec2 vec2_floor(vec2 v);
+vec2 vec2_ceil(vec2 v);
+vec2 vec2_round(vec2 v);
+void vec2_print(vec2 v);
 
 /*
  * rect types and functions
@@ -97,25 +86,25 @@ typedef struct
 } rect;
 
 #define RECT_EMPTY ((rect){0.0f, 0.0f, 0.0f, 0.0f})
-#define rectTopLeft(r) vec2f(r.x, r.y)
-#define recttopRight(r) vec2f(r.x + r.width, r.y)
-#define rectBottomLeft(r) vec2f(r.x, r.y + r.height)
-#define rectBottomRight(r) vec2f(r.x + r.width, r.y + r.height)
-#define rectSize(r) vec2f(r.width, r.height)
+#define RECT_TOP_LEFT(r) vec2f(r.x, r.y)
+#define RECT_TOP_RIGHT(r) vec2f(r.x + r.width, r.y)
+#define RECT_BOTTOM_LEFT(r) vec2f(r.x, r.y + r.height)
+#define RECT_BOTTOM_RIGHT(r) vec2f(r.x + r.width, r.y + r.height)
+#define RECT_SIZE(r) vec2f(r.width, r.height)
 
 rect rectf(f32 x, f32 y, f32 width, f32 height);
 rect recti(s32 x, s32 y, s32 width, s32 height);
 rect rectpf(f32 x1, f32 y1, f32 x2, f32 y2);
 rect rectv(vec2 pos, vec2 size);
 rect rects(vec2 size);
-bool rectContainsf(rect r, f32 x, f32 y);
-bool rectIntersects(rect r1, rect r2);
-rect rectScalef(rect r, f32 scale);
-rect rectTranslatef(rect r, f32 x, f32 y);
-vec2 rectCenter(rect r);
-rect rectExpand(rect r, f32 dx, f32 dy);
-vec2 getClosestPointOnRect(vec2 p, rect r);
-void rectPrint(rect r);
+bool rect_containsf(rect r, f32 x, f32 y);
+bool rect_intersects(rect r1, rect r2);
+rect rect_scalef(rect r, f32 scale);
+rect rect_translatef(rect r, f32 x, f32 y);
+vec2 rect_center(rect r);
+rect rect_expand(rect r, f32 dx, f32 dy);
+vec2 get_closestPointOnRect(vec2 p, rect r);
+void rect_print(rect r);
 
 /*
  * shl list/map types
@@ -124,25 +113,17 @@ void rectPrint(rect r);
 #include "shl/map.h"
 #include "shl/wstr.h"
 
-bool wt_equalsS32(const s32 a, const s32 b);
-bool wt_compareS32(const s32 a, const s32 b);
+bool equalsS32(const s32 a, const s32 b);
+bool compareS32(const s32 a, const s32 b);
+bool equalsVec2(const vec2 v1, const vec2 v2);
+bool equalsRect(const rect r1, const rect r2);
 
 shlDeclareList(s32List, s32)
-
-#define s32ListDefaultOptions (s32ListOptions){0, wt_equalsS32, NULL}
-
-bool wt_equalsVec2(const vec2 v1, const vec2 v2);
-
 shlDeclareList(vec2List, vec2)
-
-#define vec2ListDefaultOptions (vec2ListOptions){VEC2_ZERO, wt_equalsVec2, NULL}
-
-bool wt_equalsRect(const rect r1, const rect r2);
-
 shlDeclareList(rectList, rect)
-
-#define rectListDefaultOptions (rectListOptions){RECT_EMPTY, wt_equalsRect, NULL}
-
 shlDeclareMap(StringViewMap, StringView, String)
 
+#define s32ListDefaultOptions (s32ListOptions){0, equalsS32, NULL}
+#define vec2ListDefaultOptions (vec2ListOptions){VEC2_ZERO, equalsVec2, NULL}
+#define rectListDefaultOptions (rectListOptions){RECT_EMPTY, equalsRect, NULL}
 #define StringViewMapDefaultOptions (StringViewMapOptions){(String){0}, wsv_hashFNV32, wsv_equals, wstr_free}

--- a/src/war_net.c
+++ b/src/war_net.c
@@ -207,7 +207,7 @@ s32 wnet_readResponse(WarSocket sck, char responseBuffer[], s32 responseBufferLe
 
     do
     {
-        size32 sizeToRead = min(RESPONSE_READ_SIZE, responseBufferLength - responseLength);
+        size32 sizeToRead = MIN(RESPONSE_READ_SIZE, responseBufferLength - responseLength);
         if (sizeToRead <= 0)
             break;
 
@@ -408,7 +408,7 @@ bool wnet_downloadFileFromUrl(WarContext* context, StringView url, StringView fi
                 break;
             }
 
-            s32 sizeToWrite = min(chunkSize, responseLength);
+            s32 sizeToWrite = MIN(chunkSize, responseLength);
             SDL_WriteIO(stream, responsePtr, sizeToWrite);
 
             responsePtr += sizeToWrite + 2;

--- a/src/war_pathfinder.c
+++ b/src/war_pathfinder.c
@@ -50,7 +50,7 @@ static s32 compareGScore(const WarMapNode node1, const WarMapNode node2)
 
 static s32 manhattanDistance(const WarMapNode node1, const WarMapNode node2)
 {
-    return abs(node1.x - node2.x) + abs(node1.y - node2.y);
+    return ABS(node1.x - node2.x) + ABS(node1.y - node2.y);
 }
 
 static s32 nodeDistanceSqr(const WarMapNode node1, const WarMapNode node2)
@@ -410,8 +410,8 @@ bool wpath_reRoutePath(WarPathFinder finder, WarMapPath* path, s32 fromIndex, s3
 
     if (newPath.nodes.count > 1)
     {
-        s32 minIndex = min(fromIndex, toIndex);
-        s32 maxIndex = max(fromIndex, toIndex);
+        s32 minIndex = MIN(fromIndex, toIndex);
+        s32 maxIndex = MAX(fromIndex, toIndex);
 
         // remove the nodes in the range [fromIndex, toIndex] or [toIndex, fromIndex] from current to last remaining nodes of the current path
         vec2ListRemoveAtRange(&path->nodes, minIndex, maxIndex - minIndex + 1);

--- a/src/war_projectiles.c
+++ b/src/war_projectiles.c
@@ -99,7 +99,7 @@ void wproj_doProjectileSplashDamage(WarContext* context, WarEntity* entity, s32 
             {
                 WarWallPiece* piece = &pieces->items[k];
                 vec2 piecePosition = vec2i(piece->tilex, piece->tiley);
-                if (vec2DistanceInTiles(targetTile, piecePosition) <= splashRadius)
+                if (vec2_distanceInTiles(targetTile, piecePosition) <= splashRadius)
                 {
                     we_meleeWallAttack(context, sourceEntity, targetEntity, piece);
                 }
@@ -137,7 +137,7 @@ void wproj_doRainOfFireProjectileSplashDamage(WarContext* context, WarEntity* en
         {
             WarWallPiece* piece = &pieces->items[k];
             vec2 piecePosition = vec2i(piece->tilex, piece->tiley);
-            if (vec2DistanceInTiles(targetTile, piecePosition) <= splashRadius)
+            if (vec2_distanceInTiles(targetTile, piecePosition) <= splashRadius)
             {
                 we_takeWallDamage(context, targetEntity, piece, 0, RAIN_OF_FIRE_PROJECTILE_DAMAGE);
             }
@@ -156,19 +156,19 @@ bool wproj_updateProjectilePosition(WarContext* context, WarEntity* entity)
     f32 speed = (f32)projectile->speed;
     speed = wmap_getMapScaledSpeed(context, speed);
 
-    vec2 direction = vec2Subv(target, position);
-    f32 directionLength = vec2Length(direction);
+    vec2 direction = vec2_subv(target, position);
+    f32 directionLength = vec2_length(direction);
 
-    vec2 step = vec2Mulf(vec2Normalize(direction), speed * context->deltaTime);
-    f32 stepLength = vec2Length(step);
+    vec2 step = vec2_mulf(vec2_normalize(direction), speed * context->deltaTime);
+    f32 stepLength = vec2_length(step);
 
     if (directionLength < stepLength)
     {
         step = direction;
     }
 
-    vec2 newPosition = vec2Addv(position, step);
-    f32 distance = vec2Distance(newPosition, target);
+    vec2 newPosition = vec2_addv(position, step);
+    f32 distance = vec2_distance(newPosition, target);
 
     transform->position = newPosition;
 
@@ -189,15 +189,15 @@ void wproj_updateProjectileSprite(WarContext* context, WarEntity* entity)
     vec2 origin = projectile->origin;
     vec2 target = projectile->target;
 
-    f32 totalDistance = vec2Distance(origin, target);
+    f32 totalDistance = vec2_distance(origin, target);
 
-    vec2 direction = vec2Subv(target, position);
-    f32 directionLength = vec2Length(direction);
+    vec2 direction = vec2_subv(target, position);
+    f32 directionLength = vec2_length(direction);
 
     f32 travelDistance = totalDistance - directionLength;
-    f32 travelPercent = percentabf(travelDistance, totalDistance);
+    f32 travelPercent = PERCENTABF(travelDistance, totalDistance);
 
-    f32 angle = vec2ClockwiseAngle(VEC2_RIGHT, direction);
+    f32 angle = vec2_angleClockwise(VEC2_RIGHT, direction);
 
     // these are the angles at wich the frame index of the arrow
     // sprite needs to change and also where the x-scale needs to
@@ -212,8 +212,8 @@ void wproj_updateProjectileSprite(WarContext* context, WarEntity* entity)
     // find the current frame index and scale
     for (s32 i = 0; i < arrayLength(controlAngles); i++)
     {
-        if (angle >= controlAngles[i] - halff(45) &&
-            angle < controlAngles[i] + halff(45))
+        if (angle >= controlAngles[i] - 0.5f * 45 &&
+            angle < controlAngles[i] + 0.5f * 45)
         {
             newFrameIndex = frameIndices[i];
             newScale.x *= frameScales[i];
@@ -267,13 +267,13 @@ void wproj_updateRainOfFireProjectileSprite(WarContext* context, WarEntity* enti
     vec2 target = projectile->target;
     s32 frameCount = data.frameCount;
 
-    f32 totalDistance = vec2Distance(origin, target);
+    f32 totalDistance = vec2_distance(origin, target);
 
-    vec2 direction = vec2Subv(target, position);
-    f32 directionLength = vec2Length(direction);
+    vec2 direction = vec2_subv(target, position);
+    f32 directionLength = vec2_length(direction);
 
     f32 travelDistance = totalDistance - directionLength;
-    f32 travelPercent = percentabf(travelDistance, totalDistance);
+    f32 travelPercent = PERCENTABF(travelDistance, totalDistance);
 
     // the new frame index have to be changed for some projectiles
     // based on the travel percent of the projectile

--- a/src/war_resources.c
+++ b/src/war_resources.c
@@ -13,14 +13,6 @@
 #include "war_log.h"
 #include "war_audio.h"
 
-#define WAR_BUILDING_DAMAGE_1_RESOURCE 352
-#define WAR_BUILDING_DAMAGE_2_RESOURCE 353
-#define WAR_BUILDING_COLLAPSE_RESOURCE 356
-#define WAR_EXPLOSION_RESOURCE 354
-#define WAR_RAIN_OF_FIRE_EXPLOSION_RESOURCE 351
-#define WAR_SPELL_RESOURCE 355
-#define WAR_POISON_CLOUD_RESOURCE 350
-
 #define readu8(arr, index) (arr[index])
 #define reads16(arr, index) (*(s16*)((arr) + (index)))
 #define readu16(arr, index) (*(u16*)((arr) + (index)))

--- a/src/war_resources.h
+++ b/src/war_resources.h
@@ -4,6 +4,14 @@
 #include "war_units.h"
 #include "war_database.h"
 
+#define WAR_BUILDING_DAMAGE_1_RESOURCE 352
+#define WAR_BUILDING_DAMAGE_2_RESOURCE 353
+#define WAR_BUILDING_COLLAPSE_RESOURCE 356
+#define WAR_EXPLOSION_RESOURCE 354
+#define WAR_RAIN_OF_FIRE_EXPLOSION_RESOURCE 351
+#define WAR_SPELL_RESOURCE 355
+#define WAR_POISON_CLOUD_RESOURCE 350
+
 struct _WarRawResource
 {
     bool placeholder;

--- a/src/war_roads.c
+++ b/src/war_roads.c
@@ -79,10 +79,10 @@ void we_addRoadPiecesFromConstruct(WarEntity* entity, WarLevelConstruct *constru
     u8 player = construct->player;
 
     s32 dx = x2 - x1;
-    dx = sign(dx);
+    dx = SIGN(dx);
 
     s32 dy = y2 - y1;
-    dy = sign(dy);
+    dy = SIGN(dy);
 
     s32 x = x1;
     s32 y = y1;

--- a/src/war_state_machine_build.c
+++ b/src/war_state_machine_build.c
@@ -122,7 +122,7 @@ void wst_updateBuildState(WarContext* context, WarEntity* entity, WarState* stat
         return;
     }
 
-    unit->buildPercent = percentabf01(state->build.buildTime, state->build.totalBuildTime);
+    unit->buildPercent = PERCENTF01(state->build.buildTime, state->build.totalBuildTime);
 
     // update the sprite of the building to show the construction steps
     //

--- a/src/war_state_machine_cast.c
+++ b/src/war_state_machine_cast.c
@@ -83,7 +83,7 @@ void wst_updateCastState(WarContext* context, WarEntity* entity, WarState* state
                     s32 hpToRestore = unit->mana / stats.manaCost;
 
                     // take in reality how much hp needs to be restored
-                    hpToRestore = min(hpToRestore, targetUnit->maxhp - targetUnit->hp);
+                    hpToRestore = MIN(hpToRestore, targetUnit->maxhp - targetUnit->hp);
 
                     // recalculate how much mana the cleric need to spend
                     s32 manaToSpend = hpToRestore * stats.manaCost;
@@ -167,7 +167,7 @@ void wst_updateCastState(WarContext* context, WarEntity* entity, WarState* state
                     {
                         f32 offsetx = randomf(-radius, radius);
                         f32 offsety = randomf(-radius, radius);
-                        vec2 target = vec2Addv(targetTilePosition, vec2f(offsetx, offsety));
+                        vec2 target = vec2_addv(targetTilePosition, vec2f(offsetx, offsety));
 
                         offsety = randomf(MEGA_TILE_WIDTH, MEGA_TILE_WIDTH * 4);
                         vec2 origin = vec2f(target.x, map->viewport.y - offsety);
@@ -227,7 +227,7 @@ void wst_updateCastState(WarContext* context, WarEntity* entity, WarState* state
 
                     if (we_decreaseUnitMana(context, entity, stats.manaCost))
                     {
-                        we_decreaseUnitHp(context, targetEntity, halfi(targetUnit->hp));
+                        we_decreaseUnitHp(context, targetEntity, targetUnit->hp/2);
 
                         targetUnit->invulnerable = true;
                         targetUnit->invulnerabilityTime = stats.time;

--- a/src/war_state_machine_follow.c
+++ b/src/war_state_machine_follow.c
@@ -49,7 +49,7 @@ void wst_updateFollowState(WarContext* context, WarEntity* entity, WarState* sta
         }
     }
 
-    f32 distance = vec2DistanceInTiles(start, end);
+    f32 distance = vec2_distanceInTiles(start, end);
 
     // if the unit is already in distance, go to idle
     if (distance <= state->follow.distance)

--- a/src/war_state_machine_idle.c
+++ b/src/war_state_machine_idle.c
@@ -78,7 +78,7 @@ void wst_updateIdleState(WarContext* context, WarEntity* entity, WarState* state
         for(s32 i = 0; i < wall->pieces.count; i++)
         {
             WarWallPiece* piece = &wall->pieces.items[i];
-            s32 hpPercent = percentabi(piece->hp, piece->maxhp);
+            s32 hpPercent = PERCENTABI(piece->hp, piece->maxhp);
             if (hpPercent <= 0)
                 setFreeTiles(map->finder, piece->tilex, piece->tiley, 1, 1);
             else

--- a/src/war_state_machine_move.c
+++ b/src/war_state_machine_move.c
@@ -152,22 +152,22 @@ void wst_updateMoveState(WarContext* context, WarEntity* entity, WarState* state
     vec2 position = wu_getUnitCenterPosition(entity, false);
     vec2 target = wmap_tileToMapCoordinatesV(nextNode, true);
 
-    vec2 direction = vec2Subv(target, position);
-    f32 directionLength = vec2Length(direction);
+    vec2 direction = vec2_subv(target, position);
+    f32 directionLength = vec2_length(direction);
 
     f32 speed = wmap_getMapScaledSpeed(context, (f32)stats.speeds[entity->unit.speed]);
-    vec2 step = vec2Mulf(vec2Normalize(direction), speed * context->deltaTime);
-    f32 stepLength = vec2Length(step);
+    vec2 step = vec2_mulf(vec2_normalize(direction), speed * context->deltaTime);
+    f32 stepLength = vec2_length(step);
 
     if (directionLength < stepLength)
     {
         step = direction;
     }
 
-    vec2 newPosition = vec2Addv(position, step);
+    vec2 newPosition = vec2_addv(position, step);
     wu_setUnitCenterPosition(entity, newPosition, false);
 
-    f32 distance = vec2Distance(newPosition, target);
+    f32 distance = vec2_distance(newPosition, target);
     if (distance < MOVE_EPSILON)
     {
         newPosition = target;

--- a/src/war_state_machine_patrol.c
+++ b/src/war_state_machine_patrol.c
@@ -42,7 +42,7 @@ void wst_updatePatrolState(WarContext* context, WarEntity* entity, WarState* sta
     vec2 actualPosition = wmap_mapToTileCoordinatesV(entity->transform.position);
     vec2 shouldBeAt = positions.items[positions.count - 1];
 
-    f32 distance = vec2Distance(actualPosition, shouldBeAt);
+    f32 distance = vec2_distance(actualPosition, shouldBeAt);
     if (distance >= MOVE_EPSILON)
     {
         WarState* idleState = wst_createIdleState(context, entity, true);

--- a/src/war_state_machine_train.c
+++ b/src/war_state_machine_train.c
@@ -92,7 +92,7 @@ void wst_updateTrainState(WarContext* context, WarEntity* entity, WarState* stat
         return;
     }
 
-    unit->buildPercent = percentabf01(state->train.buildTime, state->train.totalBuildTime);
+    unit->buildPercent = PERCENTF01(state->train.buildTime, state->train.totalBuildTime);
 }
 
 void wst_freeTrainState(WarContext* context, WarState* state)

--- a/src/war_state_machine_upgrade.c
+++ b/src/war_state_machine_upgrade.c
@@ -84,7 +84,7 @@ void wst_updateUpgradeState(WarContext* context, WarEntity* entity, WarState* st
         return;
     }
 
-    unit->buildPercent = percentabf01(state->upgrade.buildTime, state->upgrade.totalBuildTime);
+    unit->buildPercent = PERCENTF01(state->upgrade.buildTime, state->upgrade.totalBuildTime);
 }
 
 void wst_freeUpgradeState(WarContext* context, WarState* state)

--- a/src/war_trees.c
+++ b/src/war_trees.c
@@ -239,7 +239,7 @@ s32 we_chopTree(WarContext* context, WarEntity* forest, WarTree* tree, s32 amoun
         amount = tree->amount;
 
     tree->amount -= amount;
-    tree->amount = max(tree->amount, 0);
+    tree->amount = MAX(tree->amount, 0);
 
     if (tree->amount == 0)
     {

--- a/src/war_ui.c
+++ b/src/war_ui.c
@@ -220,7 +220,7 @@ void wui_updateUICursor(WarContext* context)
     WarEntity* entity = we_findUIEntity(context, wsv_fromCString("cursor"));
     if (entity)
     {
-        entity->transform.position = vec2Subv(input->pos, entity->cursor.hot);
+        entity->transform.position = vec2_subv(input->pos, entity->cursor.hot);
         wui_changeCursorType(context, entity, WAR_CURSOR_ARROW);
     }
 }
@@ -284,7 +284,7 @@ void wui_updateUIButtons(WarContext* context, bool hotKeysEnabled)
 
             vec2 backgroundSize = vec2i(button->normalSprite.frameWidth, button->normalSprite.frameHeight);
             rect buttonRect = rectv(transform->position, backgroundSize);
-            bool pointerInside = rectContainsf(buttonRect, input->pos.x, input->pos.y);
+            bool pointerInside = rect_containsf(buttonRect, input->pos.x, input->pos.y);
 
             if (wasButtonPressed(input, WAR_MOUSE_LEFT))
             {

--- a/src/war_units.c
+++ b/src/war_units.c
@@ -1348,7 +1348,7 @@ rect wu_getUnitSpriteRect(WarEntity* entity)
 {
     vec2 frameSize = wu_getUnitFrameSize(entity);
     vec2 unitSize = wu_getUnitSpriteSize(entity);
-    vec2 pos = vec2Half(vec2Subv(frameSize, unitSize));
+    vec2 pos = vec2_half(vec2_subv(frameSize, unitSize));
     return rectv(pos, unitSize);
 }
 
@@ -1356,8 +1356,8 @@ vec2 wu_getUnitSpriteCenter(WarEntity* entity)
 {
     vec2 frameSize = wu_getUnitFrameSize(entity);
     vec2 unitSize = wu_getUnitSpriteSize(entity);
-    vec2 pos = vec2Half(vec2Subv(frameSize, unitSize));
-    return vec2Addv(pos, vec2Half(unitSize));
+    vec2 pos = vec2_half(vec2_subv(frameSize, unitSize));
+    return vec2_addv(pos, vec2_half(unitSize));
 }
 
 rect wu_getUnitRect(WarEntity* entity)
@@ -1377,8 +1377,8 @@ vec2 wu_getUnitCenterPosition(WarEntity* entity, bool inTiles)
 {
     WarTransformComponent* transform = &entity->transform;
     vec2 spriteSize = wu_getUnitSpriteSize(entity);
-    vec2 unitCenter = vec2Half(spriteSize);
-    vec2 position = vec2Addv(transform->position, unitCenter);
+    vec2 unitCenter = vec2_half(spriteSize);
+    vec2 position = vec2_addv(transform->position, unitCenter);
     return inTiles ? wmap_mapToTileCoordinatesV(position) : position;
 }
 
@@ -1401,8 +1401,8 @@ void wu_setUnitCenterPosition(WarEntity* entity, vec2 position, bool inTiles)
 
     WarTransformComponent* transform = &entity->transform;
     vec2 spriteSize = wu_getUnitSpriteSize(entity);
-    vec2 unitCenter = vec2Half(spriteSize);
-    transform->position = vec2Subv(position, unitCenter);
+    vec2 unitCenter = vec2_half(spriteSize);
+    transform->position = vec2_subv(position, unitCenter);
 }
 
 WarUnitDirection wu_getUnitDirection(WarEntity* entity)
@@ -1476,7 +1476,7 @@ vec2 wu_unitPointOnTarget(WarEntity* entity, WarEntity* targetEntity)
     vec2 unitSize = wu_getUnitSize(targetEntity);
     rect unitRect = rectv(targetPosition, unitSize);
 
-    return getClosestPointOnRect(position, unitRect);
+    return get_closestPointOnRect(position, unitRect);
 }
 
 s32 wu_entityTileDistance(WarEntity* entity, vec2 targetPosition)
@@ -1484,7 +1484,7 @@ s32 wu_entityTileDistance(WarEntity* entity, vec2 targetPosition)
     assert(isUnit(entity));
 
     vec2 position = wu_getUnitCenterPosition(entity, true);
-    f32 distance = vec2DistanceInTiles(position, targetPosition);
+    f32 distance = vec2_distanceInTiles(position, targetPosition);
     return (s32)distance;
 }
 

--- a/src/war_walls.c
+++ b/src/war_walls.c
@@ -80,10 +80,10 @@ void we_addWallPiecesFromConstruct(WarEntity* entity, WarLevelConstruct *constru
     u8 player = construct->player;
 
     s32 dx = x2 - x1;
-    dx = sign(dx);
+    dx = SIGN(dx);
 
     s32 dy = y2 - y1;
-    dy = sign(dy);
+    dy = SIGN(dy);
 
     s32 x = x1;
     s32 y = y1;


### PR DESCRIPTION
This pull request focuses on standardizing and improving the use of math and utility macros/functions throughout the codebase, as well as making related code style improvements. The changes primarily replace lowercase function calls (like `min`, `max`, `clamp`, `abs`, etc.) and custom helpers (like `halff`) with their uppercase macro equivalents (like `MIN`, `MAX`, `CLAMP`, `ABS`) or direct arithmetic, and update function names for consistency. Additionally, some minor improvements to code clarity and correctness are included.

**Math and Utility Macro Standardization:**

* Replaced usage of lowercase math functions (`min`, `max`, `clamp`, `abs`) with their uppercase macro equivalents (`MIN`, `MAX`, `CLAMP`, `ABS`) across files such as `src/war_audio.c`, `src/war_cheats.c`, and `src/war_actions.c` for consistency and to ensure macro expansion. [[1]](diffhunk://#diff-7db13e7db6e498aee1c351b694fe635a15697e322e613aa9a8787cf854ce3c97L199-R199) [[2]](diffhunk://#diff-7db13e7db6e498aee1c351b694fe635a15697e322e613aa9a8787cf854ce3c97L305-R313) [[3]](diffhunk://#diff-7db13e7db6e498aee1c351b694fe635a15697e322e613aa9a8787cf854ce3c97L425-R425) [[4]](diffhunk://#diff-c38f5e0578a5e747f56a57aea5244f3fb3485d75d3638a6b0c60b6deaf31a7ddL408-R408) [[5]](diffhunk://#diff-c38f5e0578a5e747f56a57aea5244f3fb3485d75d3638a6b0c60b6deaf31a7ddL440-R440) [[6]](diffhunk://#diff-c38f5e0578a5e747f56a57aea5244f3fb3485d75d3638a6b0c60b6deaf31a7ddL472-R472) [[7]](diffhunk://#diff-c38f5e0578a5e747f56a57aea5244f3fb3485d75d3638a6b0c60b6deaf31a7ddL486-R486) [[8]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL1167-R1178)
* Replaced custom `halff` helper function with direct multiplication by `0.5f` for better readability and to avoid unnecessary function calls in files like `src/war_animations.c` and `src/war_commands.c`. [[1]](diffhunk://#diff-5cb1a62c028c3412e09e93021a18145096c96719314df5fcf1c92aa387309d91L258-R260) [[2]](diffhunk://#diff-5cb1a62c028c3412e09e93021a18145096c96719314df5fcf1c92aa387309d91L281-R283) [[3]](diffhunk://#diff-5cb1a62c028c3412e09e93021a18145096c96719314df5fcf1c92aa387309d91L302-R304) [[4]](diffhunk://#diff-5cb1a62c028c3412e09e93021a18145096c96719314df5fcf1c92aa387309d91L323-R325) [[5]](diffhunk://#diff-5cb1a62c028c3412e09e93021a18145096c96719314df5fcf1c92aa387309d91L344-R346) [[6]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L54-R55) [[7]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L66-R67) [[8]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L78-R79)

**Function and Naming Consistency:**

* Updated various geometric and vector utility function calls to use a consistent lowercase and underscore-separated naming convention (e.g., `rectContainsf` → `rect_containsf`, `rectCenter` → `rect_center`, `vec2Distance` → `vec2_distance`) in `src/war_audio.c` and `src/war_commands.c`. [[1]](diffhunk://#diff-7db13e7db6e498aee1c351b694fe635a15697e322e613aa9a8787cf854ce3c97L412-R415) [[2]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L595-R595) [[3]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L604-R604) [[4]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L630-R630) [[5]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L688-R688) [[6]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L715-R715) [[7]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L743-R743) [[8]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L855-R855) [[9]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L896-R896) [[10]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L944-R944)

**Other Improvements:**

* Added a missing include for `war_resources.h` in `src/war_animations.c` to ensure resource references are available.
* Updated calculation of health percentage to use the macro `PERCENTABI` instead of `percentabi` for consistency in `src/war_audio.c`.
* Refactored vector and offset calculations for animation creation functions to improve clarity and accuracy in `src/war_animations.c`.

These changes collectively improve code consistency, readability, and maintainability across the project.