### PR TITLE
Refactor action system to simplify unit action steps

### DIFF
--- a/docs/ACTION_SYSTEM.md
+++ b/docs/ACTION_SYSTEM.md
@@ -1,0 +1,749 @@
+# War1-C Action System Documentation
+
+## Overview
+
+The Action System is the core animation and behavior framework in War1-C. It manages all animated sequences for game units, including walking, attacking, harvesting, repairing, building, and dying animations. The system is data-driven, frame-based, and directional-aware, meaning animations can adapt based on unit direction (8 directions).
+
+Each unit type (Footman, Grunt, Peasant, Peon, Archer, etc.) has pre-defined action definitions that describe exactly what happens frame-by-frame during each animation sequence.
+
+---
+
+## Architecture
+
+### Core Concepts
+
+The action system operates on three levels:
+
+1. **Action Definition (WarUnitActionDef)** - Static, pre-defined animation data loaded once at game start
+2. **Action State (WarUnitAction)** - Per-unit runtime state tracking progress through an action
+3. **Action Step (WarUnitActionStep)** - Individual atomic commands executed during an action (frame, wait, sound, attack)
+
+### Key Types
+
+#### `WarUnitActionStepType` - Enum of Step Commands
+
+Each step in an action is one of these types:
+
+```c
+typedef enum _WarUnitActionStepType
+{
+    WAR_ACTION_STEP_NONE,            // No-op (default)
+    WAR_ACTION_STEP_FRAME,           // Display a sprite frame
+    WAR_ACTION_STEP_WAIT,            // Pause for N frames
+    WAR_ACTION_STEP_ATTACK,          // Trigger attack damage event
+    WAR_ACTION_STEP_SOUND_SWORD,     // Play sword swing sound
+    WAR_ACTION_STEP_SOUND_FIST,      // Play punch sound
+    WAR_ACTION_STEP_SOUND_FIREBALL,  // Play fireball sound
+    WAR_ACTION_STEP_SOUND_CHOPPING,  // Play chopping/harvesting sound
+    WAR_ACTION_STEP_SOUND_CATAPULT,  // Play catapult launch sound
+    WAR_ACTION_STEP_SOUND_ARROW,     // Play arrow shot sound
+    WAR_ACTION_STEP_SOUND_LIGHTNING, // Play lightning sound
+} WarUnitActionStepType;
+```
+
+#### `WarUnitActionType` - Enum of Action Categories
+
+```c
+typedef enum _WarUnitActionType
+{
+    WAR_ACTION_TYPE_NONE = -1,
+    WAR_ACTION_TYPE_IDLE,       // Standing/waiting (loops)
+    WAR_ACTION_TYPE_WALK,       // Movement animation (loops)
+    WAR_ACTION_TYPE_ATTACK,     // Combat swing/cast (loops)
+    WAR_ACTION_TYPE_DEATH,      // Unit dies (loops at end frame)
+    WAR_ACTION_TYPE_HARVEST,    // Worker gathering resources (loops)
+    WAR_ACTION_TYPE_REPAIR,     // Worker repairing buildings (loops)
+    WAR_ACTION_TYPE_BUILD,      // Worker building structure (loops)
+    WAR_ACTION_TYPE_COUNT
+} WarUnitActionType;
+```
+
+#### `WarUnitActionStatus` - Execution State
+
+```c
+typedef enum _WarUnitActionStatus
+{
+    WAR_ACTION_NOT_STARTED,  // Never begun or explicitly reset
+    WAR_ACTION_RUNNING,      // Currently playing
+    WAR_ACTION_FINISHED,     // Completed (for non-looping actions)
+} WarUnitActionStatus;
+```
+
+#### `WarUnitActionStep` - Single Step in an Action
+
+```c
+struct _WarUnitActionStep
+{
+    WarUnitActionStepType type;  // What to do
+    s32 param;                   // Type-dependent parameter (frame index, duration, etc.)
+};
+```
+
+#### `WarUnitActionDef` - Full Animation Definition
+
+```c
+struct _WarUnitActionDef
+{
+    WarUnitActionType type;      // IDLE, WALK, ATTACK, etc.
+    bool directional;            // Does direction affect frame offset?
+    bool loop;                   // Should this repeat when finished?
+    WarUnitActionStepList steps; // Array of all steps to execute
+};
+```
+
+Directional actions (walk, attack, etc.) adapt the sprite frame index based on unit direction. Non-directional actions (build) always show the same animation regardless of facing.
+
+#### `WarUnitAction` - Runtime Action State
+
+```c
+struct _WarUnitAction
+{
+    WarUnitActionStatus status;       // NOT_STARTED, RUNNING, or FINISHED
+    f32 scale;                        // Speed multiplier (1.0 = normal, 2.0 = twice as fast)
+    f32 waitCount;                    // Frames remaining in current WAIT step
+    s32 stepIndex;                    // Position in action's step array
+    WarUnitActionStepType lastActionStep;  // Last ATTACK step played this frame
+    WarUnitActionStepType lastSoundStep;   // Last SOUND step played this frame
+};
+```
+
+---
+
+## API Reference
+
+### Initialization
+
+#### `void wact_initUnitActionDefs(void)`
+
+**Purpose:** Bootstrap all unit action definitions at game start.
+
+**When to call:** Once during game initialization (called from `wg_initGame()`).
+
+**What it does:**
+- Initializes the global action definition table for all unit types
+- Pre-computes frame sequences based on spritesheet layout
+- Sets up timing parameters (walk speed, attack speed, etc.)
+
+**Example:**
+```c
+void wg_initGame(WarContext* context)
+{
+    // ... other init code ...
+    wact_initUnitActionDefs();  // Action system ready
+    // ... rest of init ...
+}
+```
+
+---
+
+### Per-Unit Setup
+
+#### `void wact_addUnitActions(WarEntity* entity)`
+
+**Purpose:** Initialize action state for a newly created unit.
+
+**Parameters:**
+- `entity` - The unit entity to set up
+
+**When to call:** When a unit is spawned (called during entity creation).
+
+**What it does:**
+- Allocates and zeroes the `actions` array on the unit component
+- Sets all actions to NOT_STARTED status
+- Sets scale to 1.0 and clears frame counters
+
+**Example:**
+```c
+// In unit creation code
+WarEntity* footman = we_createEntity(context, ...);
+wu_initUnit(footman, WAR_UNIT_FOOTMAN);
+wact_addUnitActions(footman);  // Ready to animate
+```
+
+---
+
+### Action Control
+
+#### `void wact_setAction(WarContext* context, WarEntity* entity, WarUnitActionType type, bool reset, f32 scale)`
+
+**Purpose:** Transition a unit to a new action or update the current action's parameters.
+
+**Parameters:**
+- `context` - Game context (for potential future updates)
+- `entity` - Unit to animate
+- `type` - Target action type (IDLE, WALK, ATTACK, etc.), or WAR_ACTION_TYPE_NONE to stop
+- `reset` - If true, restart from step 0; if false, resume or keep current progress
+- `scale` - Speed multiplier (1.0 = normal, 2.0 = 2x speed). Use -1.0 to keep current scale.
+
+**What it does:**
+- Changes the unit's `actionType` to the specified type
+- If `reset` is true, resets `stepIndex` to 0 and status to NOT_STARTED
+- If `scale >= 0`, updates the action's `scale` multiplier
+
+**Common usage patterns:**
+
+```c
+// Start walking from the beginning (restart animation)
+wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, 1.0f);
+
+// Start attacking from the beginning
+wact_setAction(context, unit, WAR_ACTION_TYPE_ATTACK, true, 1.0f);
+
+// Transition to idle without restarting (resume if paused)
+wact_setAction(context, unit, WAR_ACTION_TYPE_IDLE, false, 1.0f);
+
+// Stop animating
+wact_setAction(context, unit, WAR_ACTION_TYPE_NONE, false, 1.0f);
+
+// Keep current scale, just resume/restart
+wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, -1.0f);
+```
+
+---
+
+#### `void wact_updateAction(WarContext* context, WarEntity* entity)`
+
+**Purpose:** Advance an action by one frame and apply animation effects.
+
+**Parameters:**
+- `context` - Game context (includes `deltaTime`)
+- `entity` - Unit to update
+
+**When to call:** Every game loop frame (called from game update).
+
+**What it does:**
+1. Checks if the unit has an active action
+2. Decrements the wait counter based on delta time
+3. When wait expires, advances to the next step
+4. Processes all non-WAIT steps (FRAME, ATTACK, SOUND)
+5. Applies directional frame offset for directional actions
+6. Triggers sound effects and attack damage callbacks
+7. Handles looping or finishing
+
+**Frame-by-Frame Breakdown:**
+
+```
+Loop iteration 1:
+  - Current step: WAIT(6)
+  - waitCount -= deltaTime
+  - waitCount > 0? Yes, return early
+  - No frame change
+
+Loop iteration 2-6:
+  - waitCount becomes <= 0
+  - Advance to next step
+
+Loop iteration 7:
+  - Current step: FRAME(5)
+  - Process FRAME: display frame 5 (with directional offset)
+  - stepIndex++
+  - Process next non-WAIT steps...
+  - Eventually reach next WAIT, set waitCount
+```
+
+---
+
+### Query
+
+#### `s32 wact_getActionDuration(WarEntity* entity, WarUnitActionType type)`
+
+**Purpose:** Calculate the total duration of an action in frames.
+
+**Parameters:**
+- `entity` - Unit (used to look up the correct action definition by unit type)
+- `type` - Action type to query (IDLE, WALK, ATTACK, etc.)
+
+**Returns:** Total frame count (sum of all WAIT step durations) for that action.
+
+**Use cases:**
+- Predict when an action will finish
+- Delay other tasks until an action completes
+- Time enemy AI decisions
+
+**Example:**
+```c
+s32 attackFrames = wact_getActionDuration(unit, WAR_ACTION_TYPE_ATTACK);
+// Player will be vulnerable for attackFrames/FRAMES_PER_SECONDS seconds
+schedulePlayerAction(attackFrames);
+```
+
+---
+
+## Data-Driven Action Definition
+
+### How Actions Are Built
+
+Actions are built at initialization time by combining **action definition functions** that construct `WarUnitActionDef` objects. Each unit type gets custom actions based on its spritesheet layout.
+
+#### Frame Sequence Generation: `wact_getFrameNumbers()`
+
+The spritesheet for each unit contains:
+- Walk frames (consecutive)
+- Attack frames (consecutive)
+- Death frames (consecutive)
+
+These are interleaved in a specific order. The `wact_getFrameNumbers()` function takes the frame counts and spreads them across a visual grid:
+
+```
+Spritesheet layout (example: Footman with 5 directions, 5 walk, 5 attack, 3 death):
+
+Direction: N   NE   E   SE   S   SW   W   NW
+Frame 1:   W1  W2   W3  W4  W5   A1  A2   A3
+Frame 2:   A4  A5   D1  D2  D3   W1  W2   W3
+...
+
+This function remaps them so each direction gets the correct subset.
+```
+
+#### Action Definition Builders
+
+Several helper functions create standard actions:
+
+##### `createWalkActionDef()` - Oscillating Walk Animation
+
+```c
+static WarUnitActionDef createWalkActionDef(
+    s32 nframes,              // Number of walk frames (e.g., 5)
+    s32 frames[],             // Frame indices
+    s32 walkSpeed,            // Delay between each frame (e.g., 6)
+    bool directional          // Does direction matter?
+)
+```
+
+Generates a looping walk by oscillating forward and backward through frames:
+```
+Sequence: [0, W, 0, W, 0]
+Then:     [NW, NW-1, NW-2, NW-1]
+Loop
+```
+
+**Example setup:**
+```c
+s32 walkFrames[] = {0, 5, 10, 15, 20};  // 5 walk frame offsets
+WarUnitActionDef walkDef = createWalkActionDef(5, walkFrames, 6, true);
+// Result: Smooth 8-directional walk with 6-frame timing
+```
+
+##### `createAttackActionDef()` - Combat Swing with Sound & Damage
+
+```c
+static WarUnitActionDef createAttackActionDef(
+    s32 nframes,              // Number of attack frames (e.g., 5)
+    s32 frames[],             // Frame indices
+    s32 attackSpeed,          // Delay between frames
+    s32 attackSound,          // Sound to play (e.g., WAR_ACTION_STEP_SOUND_SWORD)
+    s32 coolOffTime,          // Recovery frames after animation
+    bool directional
+)
+```
+
+Generates an attack that:
+- Cycles through frames
+- At the midpoint frame, triggers `WAR_ACTION_STEP_ATTACK` (damage event)
+- At the midpoint frame, plays the attack sound
+- Pads shorter attacks to normalize duration (5 frames max)
+- Adds cool-off time before next attack
+
+**Example:**
+```c
+s32 attackFrames[] = {25, 30, 35, 40, 45};
+WarUnitActionDef attackDef = createAttackActionDef(
+    5, attackFrames, 6, WAR_ACTION_STEP_SOUND_SWORD, 1, true
+);
+// Result: Sword swing that damages at frame 3, plays "sword" sound, then waits 1 frame before idle
+```
+
+##### `createHarvestActionDef()` - Resource Gathering
+
+```c
+static WarUnitActionDef createHarvestActionDef(
+    s32 nframes,              // Number of harvest frames
+    s32 frames[],
+    s32 harvestSpeed,         // Delay between frames
+    s32 harvestSound,         // Sound effect
+    s32 coolOffTime,
+    bool directional
+)
+```
+
+Similar to attack but includes:
+- Initial 5-frame wait before starting (picking up stance)
+- Harvest sound and resource delivery trigger at midpoint
+- Used for chopping trees, mining gold, etc.
+
+##### `createDeathActionDef()` - Unit Destruction
+
+```c
+static WarUnitActionDef createDeathActionDef(
+    s32 nframes,
+    s32 frames[],
+    s32 waitTime,             // Delay between frames
+    bool directional,
+    bool doWait101Step        // Some units use special 100+ frame wait for decay
+)
+```
+
+Non-looping action that:
+- Plays through all frames once
+- Optionally adds a long pause before final frame (body decay)
+- Loops at the final frame (unit stays dead)
+
+---
+
+## Real-World Examples
+
+### Example 1: Making a Unit Walk
+
+```c
+WarEntity* grunt = // ... find or create unit ...
+
+// Start walking
+wact_setAction(context, grunt, WAR_ACTION_TYPE_WALK, true, 1.0f);
+
+// Each game frame:
+wact_updateAction(context, grunt);
+// - Advances through walk animation steps
+// - Updates sprite frame based on grunt's direction
+// - Loops seamlessly
+```
+
+### Example 2: Attack Sequence
+
+```c
+WarEntity* footman = // ... unit to attack ...
+WarEntity* target = // ... enemy unit ...
+
+// Start attacking
+wact_setAction(context, footman, WAR_ACTION_TYPE_ATTACK, true, 1.0f);
+
+// In game loop:
+wact_updateAction(context, footman);
+// When the midpoint frame is reached:
+//   - WAR_ACTION_STEP_ATTACK is processed
+//   - Attack callback fires, dealing damage to target
+//   - Sword sound effect plays
+//   - Animation continues through recovery frames
+```
+
+### Example 3: Worker Harvesting
+
+```c
+WarEntity* peasant = // ... worker unit ...
+
+// Start harvesting (chopping trees or mining)
+wact_setAction(context, peasant, WAR_ACTION_TYPE_HARVEST, true, 1.0f);
+
+// Loop:
+wact_updateAction(context, peasant);
+// - Waits 5 frames (pickup pose)
+// - Cycles through chop frames
+// - At midpoint, "chopping" sound plays
+// - Cooloff period before next harvest
+// - Loops back to start
+```
+
+### Example 4: Speed Variation
+
+```c
+WarEntity* knight = // ... mounted unit ...
+
+// Normal speed
+wact_setAction(context, knight, WAR_ACTION_TYPE_WALK, true, 1.0f);
+
+// Get faster (fleeing or upgraded)
+wact_setAction(context, knight, WAR_ACTION_TYPE_WALK, false, 1.5f);
+// All wait times are multiplied by 1.5, so animation plays 1.5x faster
+
+// Back to normal
+wact_setAction(context, knight, WAR_ACTION_TYPE_WALK, false, 1.0f);
+```
+
+### Example 5: Querying Animation Duration
+
+```c
+s32 deathFrames = wact_getActionDuration(unit, WAR_ACTION_TYPE_DEATH);
+// If deathFrames == 60 and FRAMES_PER_SECONDS == 50
+// Then death takes 60/50 = 1.2 seconds
+
+// Schedule cleanup after death animation
+f32 deathDuration = (f32)deathFrames / FRAMES_PER_SECONDS;
+scheduleEntityRemoval(entity, deathDuration);
+```
+
+---
+
+## Directional Animation
+
+Actions can be marked as `directional` or non-directional.
+
+### Directional Actions (walk, attack, idle, etc.)
+
+The sprite frame offset is computed from the unit's current direction:
+
+```c
+if (actionDef->directional)
+{
+    frameIndex += (4 - ABS(4 - (s32)unit->direction));
+    
+    // Mirror horizontally for certain directions
+    transform->scale.x = inRange(unit->direction, WAR_DIRECTION_SOUTH_WEST, WAR_DIRECTION_COUNT) ? -1.0f : 1.0f;
+}
+```
+
+**Direction mapping (8 compass directions):**
+```
+0 = NORTH       (up)         -> no offset, no flip
+1 = NORTH_EAST  (up-right)   -> offset 1, no flip
+2 = EAST        (right)      -> offset 2, no flip
+3 = SOUTH_EAST  (down-right) -> offset 3, no flip
+4 = SOUTH       (down)       -> offset 4, flip X
+5 = SOUTH_WEST  (down-left)  -> offset 3, flip X
+6 = WEST        (left)       -> offset 2, flip X
+7 = NORTH_WEST  (up-left)    -> offset 1, flip X
+```
+
+So a walk animation with 5 frames becomes an 8-directional walk by selecting different frame offsets and flipping.
+
+### Non-Directional Actions (build)
+
+Frame offset is **always 0**, regardless of direction. The animation plays the same way from any angle.
+
+---
+
+## Action Definition Tables
+
+### Global Action Definition Storage
+
+```c
+static WarUnitActionDef gUnitActionDefs[WAR_UNIT_COUNT][WAR_ACTION_TYPE_COUNT];
+```
+
+This 2D array stores all pre-built action definitions:
+- **First dimension:** Unit type (Footman, Grunt, Peasant, etc.)
+- **Second dimension:** Action type (IDLE, WALK, ATTACK, etc.)
+
+Each cell is a `WarUnitActionDef` with a complete sequence of steps.
+
+### Per-Unit Type Initialization
+
+Each unit type gets its own init function:
+
+```c
+static void initFootmanGruntActionDefs(WarUnitFrameNumbers frames)
+{
+    // Set animation timing parameters for this unit type
+    s32 walkSpeed = 6;        // Fast walk
+    s32 attackSpeed = 6;      // Fast attack
+    s32 coolOffTime = 1;
+    s32 waitTime = 3;
+    bool directional = true;
+
+    // Build action definitions
+    WarUnitActionDef idleDef = createDefaultIdleActionDef(waitTime, directional);
+    WarUnitActionDef walkDef = createWalkActionDef(frames.walkFramesCount, frames.walkFrames, walkSpeed, directional);
+    WarUnitActionDef attackDef = createAttackActionDef(frames.attackFramesCount, frames.attackFrames, attackSpeed, WAR_ACTION_STEP_SOUND_SWORD, coolOffTime, directional);
+    WarUnitActionDef deathDef = createDeathActionDef(frames.deathFramesCount, frames.deathFrames, waitTime, directional, true);
+
+    // Register for both Footman and Grunt (they share animations)
+    WarUnitType unitTypes[] = {WAR_UNIT_FOOTMAN, WAR_UNIT_GRUNT};
+    for (s32 i = 0; i < arrayLength(unitTypes); i++)
+    {
+        WarUnitType unitType = unitTypes[i];
+        gUnitActionDefs[unitType][WAR_ACTION_TYPE_IDLE] = idleDef;
+        gUnitActionDefs[unitType][WAR_ACTION_TYPE_WALK] = walkDef;
+        gUnitActionDefs[unitType][WAR_ACTION_TYPE_ATTACK] = attackDef;
+        gUnitActionDefs[unitType][WAR_ACTION_TYPE_DEATH] = deathDef;
+    }
+}
+```
+
+This pattern is repeated for every unit type: Peasants (with harvest/repair), Archers, Catapults, Cavalry, Mages, Demons, etc.
+
+---
+
+## Integration Points
+
+### Game Loop Integration
+
+```c
+void wg_updateGame(WarContext* context)
+{
+    // ... other updates ...
+
+    // Update all entities
+    for (s32 i = 0; i < context->entities.count; i++)
+    {
+        WarEntity* entity = context->entities.items[i];
+        
+        // Update action/animation
+        wact_updateAction(context, entity);
+        
+        // Update sprite based on action
+        wr_updateEntitySprite(context, entity);
+    }
+
+    // ... render ...
+}
+```
+
+### State Machine Integration
+
+Actions are used by the **State Machine** (FSM) to animate units as they transition between behaviors:
+
+```c
+void wst_idle(WarContext* context, WarEntity* entity)
+{
+    // While idle, play idle animation
+    wact_setAction(context, entity, WAR_ACTION_TYPE_IDLE, false, 1.0f);
+}
+
+void wst_move(WarContext* context, WarEntity* entity)
+{
+    // While moving, play walk animation
+    wact_setAction(context, entity, WAR_ACTION_TYPE_WALK, true, 1.0f);
+}
+
+void wst_attack(WarContext* context, WarEntity* entity)
+{
+    // While attacking, play attack animation
+    wact_setAction(context, entity, WAR_ACTION_TYPE_ATTACK, true, 1.0f);
+    
+    // When attack animation finishes, FSM transitions back to idle/move
+}
+```
+
+---
+
+## Performance Notes
+
+### Pre-computation
+- All action definitions are built **once** at game startup (`wact_initUnitActionDefs`)
+- Runtime `wact_updateAction` only advances counters and indices—very fast
+- No per-frame allocation or searching
+
+### Memory Efficiency
+- Shared action definitions across unit types (Footman & Grunt share walk/attack)
+- Tight `WarUnitAction` struct (3 integers + 2 floats = 20 bytes per unit per action type)
+- Step arrays are reasonably sized (typically 20-100 steps per action)
+
+### Delta-Time Scaling
+- Wait times are scaled by delta time: `waitCount -= wmap_getMapScaledSpeed(context, deltaTime)`
+- Allows smooth frame-rate independence
+- Speed multiplier (`scale`) provides further control
+
+---
+
+## Common Pitfalls
+
+### 1. Forgetting to Initialize
+```c
+// WRONG: entity->unit.actions not initialized
+wact_setAction(context, entity, WAR_ACTION_TYPE_WALK, true, 1.0f);
+
+// CORRECT: Always call wact_addUnitActions after creating a unit
+WarEntity* unit = we_createEntity(...);
+wu_initUnit(unit, unitType);
+wact_addUnitActions(unit);  // <-- Don't forget!
+```
+
+### 2. Wrong Scale Parameter
+```c
+// WRONG: Using 0 as "keep current scale"
+wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, 0.0f);  // Freezes animation!
+
+// CORRECT: Use -1.0f to preserve scale, or provide positive value
+wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, -1.0f);  // Keep scale
+wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, 1.0f);   // Reset to normal
+```
+
+### 3. Not Calling Update
+```c
+// WRONG: Set action but never call update
+wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, 1.0f);
+// ... unit never animates!
+
+// CORRECT: Call update in game loop
+for (frame in game)
+{
+    wact_setAction(context, unit, WAR_ACTION_TYPE_WALK, true, 1.0f);
+    wact_updateAction(context, unit);  // <-- Necessary!
+}
+```
+
+### 4. Direction Changes During Action
+```c
+// CORRECT: Direction changes apply immediately on next update
+unit->transform.direction = WAR_DIRECTION_EAST;
+wact_updateAction(context, unit);  // Frame offset recalculated with new direction
+```
+
+---
+
+## Extension Points
+
+### Adding a New Action Type
+
+1. Add the enum value to `WarUnitActionType` in `war_enums.h`:
+```c
+typedef enum _WarUnitActionType
+{
+    // ... existing ...
+    WAR_ACTION_TYPE_CAST,   // NEW: Magic casting animation
+    WAR_ACTION_TYPE_COUNT
+} WarUnitActionType;
+```
+
+2. Create a builder function in `war_actions.c`:
+```c
+static WarUnitActionDef createCastActionDef(...)
+{
+    WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_CAST, directional, true);
+    // Add steps...
+    return def;
+}
+```
+
+3. Register it in the unit init functions:
+```c
+gUnitActionDefs[unitType][WAR_ACTION_TYPE_CAST] = castDef;
+```
+
+4. Use it in the FSM:
+```c
+void wst_cast(WarContext* context, WarEntity* entity)
+{
+    wact_setAction(context, entity, WAR_ACTION_TYPE_CAST, true, 1.0f);
+}
+```
+
+### Adding a New Sound Step
+
+1. Add to `WarUnitActionStepType` enum:
+```c
+WAR_ACTION_STEP_SOUND_MAGIC,
+```
+
+2. Handle in `wact_updateAction`:
+```c
+case WAR_ACTION_STEP_SOUND_MAGIC:
+{
+    action->lastSoundStep = step.type;
+    break;
+}
+```
+
+3. Add sound playback logic in sprite/audio rendering layer (check `action->lastSoundStep`)
+
+---
+
+## Summary
+
+The Action System provides:
+- ✅ **Data-driven animations** - Defined at startup, not hard-coded
+- ✅ **8-directional support** - Directional actions adapt to unit facing
+- ✅ **Synchronized events** - Damage and sounds trigger at exact animation frames
+- ✅ **Speed control** - Frame-rate independent with multiplier support
+- ✅ **Loop support** - Both one-shot and repeating animations
+- ✅ **Per-unit customization** - Each unit type has unique timing and frame sequences
+
+All animations flow through `wact_setAction` (start/change) and `wact_updateAction` (advance), making the system simple, efficient, and easy to extend.

--- a/docs/ANIMATION_SYSTEM.md
+++ b/docs/ANIMATION_SYSTEM.md
@@ -1,0 +1,865 @@
+# War1-C Animation System Documentation
+
+## Overview
+
+The Animation System is a sprite frame sequence engine for one-off visual effects and overlays. While the **Action System** handles unit animations (walk, attack, idle), the **Animation System** manages temporary visual effects that play independently on top of units or the map.
+
+Common animations include:
+- **Building Damage Overlays** - Visual indicators when a building is damaged
+- **Explosions** - Detonations from catapult shots, buildings collapsing
+- **Spells** - Visual effects for magical attacks (fireball, lightning)
+- **Environmental Effects** - Poison clouds, rain of fire, building collapse sequences
+- **Custom Frame Sequences** - Any sprite sheet that needs to cycle through frames
+
+Unlike the Action System which loops indefinitely and is tightly integrated with unit state machines, animations are **temporal** — they play once (or loop a fixed number of times) and self-destruct when finished.
+
+---
+
+## Architecture
+
+### Core Concept: Sprite Animation as a Component
+
+Animations are managed as a **component** that can be attached to any entity. An entity can have **multiple simultaneous animations**, allowing layering of effects (e.g., a building that is both damaged AND being repaired).
+
+```
+Entity
+├── Transform Component
+├── Sprite Component (unit sprite)
+├── Unit Component (stats, health)
+└── Animations Component
+    ├── Animation 1 (damage overlay)
+    ├── Animation 2 (collapse effect)
+    └── Animation 3 (custom effect)
+```
+
+Each animation plays independently, with its own frame counter, duration, and playback status.
+
+### Key Types
+
+#### `WarAnimationStatus` - Execution State
+
+```c
+typedef enum _WarAnimationStatus
+{
+    WAR_ANIM_STATUS_NOT_STARTED,  // Created but not yet playing
+    WAR_ANIM_STATUS_RUNNING,      // Currently playing
+    WAR_ANIM_STATUS_FINISHED,     // Complete (will be removed)
+} WarAnimationStatus;
+```
+
+#### `WarSpriteAnimation` - Single Animation Instance
+
+```c
+struct _WarSpriteAnimation
+{
+    String name;              // Unique identifier (e.g., "explosion_123.45_67.89")
+    bool loop;                // Should this repeat or play once?
+    f32 loopDelay;            // Pause (in seconds) between loop iterations
+
+    vec2 offset;              // Position offset from entity origin
+    vec2 scale;               // Scaling (1.0 = normal, 2.0 = 2x)
+
+    f32 frameDelay;           // Duration of each frame (in seconds)
+    s32List frames;           // Sequence of frame indices to display
+
+    WarSprite sprite;         // Sprite resource (contains frame dimensions)
+
+    f32 animTime;             // Current playback time (0.0 to 1.0 normalized)
+    f32 loopTime;             // Countdown for loop delay
+    WarAnimationStatus status;// NOT_STARTED, RUNNING, or FINISHED
+};
+```
+
+#### `WarAnimationsComponent` - Container for All Animations on an Entity
+
+```c
+struct _WarAnimationsComponent
+{
+    bool enabled;                        // Can animations play?
+    WarSpriteAnimationList animations;   // List of active animations
+};
+```
+
+---
+
+## API Reference
+
+### Creation
+
+#### `WarSpriteAnimation* wanim_createAnimation(WarContext* context, String name, WarSprite sprite, f32 frameDelay, bool loop)`
+
+**Purpose:** Create a custom animation from scratch.
+
+**Parameters:**
+- `context` - Game context
+- `name` - Unique identifier for this animation (e.g., "my_effect_001")
+- `sprite` - Sprite resource (dimensions and frame data)
+- `frameDelay` - Duration per frame in seconds (e.g., 0.1f = 10 FPS)
+- `loop` - Repeat after finishing?
+
+**Returns:** Pointer to newly allocated `WarSpriteAnimation`
+
+**What it does:**
+- Allocates memory for the animation
+- Initializes status to NOT_STARTED
+- Sets offset and scale to default (origin, 1x)
+- Prepares an empty frame list
+
+**Example:**
+```c
+WarSprite explosionSprite = wspr_createSpriteFromResourceIndex(
+    context, imageResourceRef(WAR_EXPLOSION_RESOURCE)
+);
+WarSpriteAnimation* explosion = wanim_createAnimation(
+    context, 
+    "explosion_hit",
+    explosionSprite,
+    0.1f,  // 100ms per frame = 10 FPS
+    false  // Play once
+);
+```
+
+---
+
+#### `WarSpriteAnimation* wanim_createAnimationFromResourceIndex(WarContext* context, String name, WarSpriteResourceRef spriteResourceRef, f32 frameDelay, bool loop)`
+
+**Purpose:** Create an animation directly from a resource ID (convenience wrapper).
+
+**Parameters:**
+- `context` - Game context
+- `name` - Animation identifier
+- `spriteResourceRef` - Resource reference ID
+- `frameDelay` - Duration per frame
+- `loop` - Repeat?
+
+**Returns:** New animation instance
+
+**What it does:**
+- Loads the sprite from the resource database
+- Calls `wanim_createAnimation` with the loaded sprite
+
+**Example:**
+```c
+WarSpriteAnimation* damage = wanim_createAnimationFromResourceIndex(
+    context,
+    "damage_indicator",
+    imageResourceRef(WAR_BUILDING_DAMAGE_1_RESOURCE),
+    0.2f,
+    true  // Damage indicator loops
+);
+```
+
+---
+
+### Frame Setup
+
+#### `void wanim_addAnimationFrame(WarSpriteAnimation* animation, s32 frameIndex)`
+
+**Purpose:** Add a single frame to an animation's playback sequence.
+
+**Parameters:**
+- `animation` - Animation to modify
+- `frameIndex` - Index in the sprite sheet to display
+
+**What it does:**
+- Appends `frameIndex` to the animation's frame list
+
+**Example:**
+```c
+// Create a 6-frame explosion
+for (s32 i = 0; i < 6; i++)
+{
+    wanim_addAnimationFrame(explosion, i);
+}
+```
+
+---
+
+#### `void wanim_addAnimationFrames(WarSpriteAnimation* animation, s32 count, s32 frameIndices[])`
+
+**Purpose:** Add multiple frames in one call.
+
+**Parameters:**
+- `animation` - Animation to modify
+- `count` - Number of frames
+- `frameIndices[]` - Array of frame indices (or NULL for 0..count-1 sequence)
+
+**What it does:**
+- If `frameIndices` is provided, adds those exact frames
+- If `frameIndices` is NULL, adds frames 0, 1, 2, ..., count-1
+
+**Example:**
+```c
+// Method 1: Explicit frame list
+s32 frames[] = {0, 1, 2, 3, 4, 5};
+wanim_addAnimationFrames(explosion, 6, frames);
+
+// Method 2: Sequential (0..5)
+wanim_addAnimationFrames(explosion, 6, NULL);  // Same result
+```
+
+---
+
+#### `void wanim_addAnimationFramesRange(WarSpriteAnimation* animation, s32 from, s32 to)`
+
+**Purpose:** Add a range of frames (forward or backward).
+
+**Parameters:**
+- `animation` - Animation to modify
+- `from` - Starting frame index
+- `to` - Ending frame index
+
+**What it does:**
+- If `from < to`, adds frames `from, from+1, ..., to`
+- If `from > to`, adds frames `from, from-1, ..., to` (reverse)
+
+**Example:**
+```c
+// Forward: frames 0, 1, 2, 3, 4
+wanim_addAnimationFramesRange(anim, 0, 4);
+
+// Reverse: frames 10, 9, 8, 7
+wanim_addAnimationFramesRange(anim, 10, 7);
+
+// Ping-pong effect: forward then backward
+wanim_addAnimationFramesRange(anim, 0, 5);      // 0..5
+wanim_addAnimationFramesRange(anim, 4, 1);      // 4,3,2,1
+```
+
+---
+
+### Animation Attachment
+
+#### `void wanim_addAnimation(WarEntity* entity, WarSpriteAnimation* animation)`
+
+**Purpose:** Attach a created animation to an entity.
+
+**Parameters:**
+- `entity` - Target entity
+- `animation` - Animation to attach
+
+**What it does:**
+- Adds the animation to the entity's animations component
+- Animation will be updated/rendered each frame
+
+**Example:**
+```c
+WarEntity* target = // ... unit being attacked ...
+WarSpriteAnimation* explosion = wanim_createAnimation(...);
+wanim_addAnimation(target, explosion);  // Animation plays on top of unit
+```
+
+---
+
+### Positioning & Transform
+
+**Animation Position:**
+- Animations are positioned using `offset` (relative to entity origin)
+- Scaled using the `scale` field
+- Can be set directly after creation:
+
+```c
+WarSpriteAnimation* effect = wanim_createAnimation(...);
+effect->offset = vec2f(50.0f, -30.0f);  // Offset from entity
+effect->scale = vec2f(1.5f, 1.5f);      // 1.5x size
+wanim_addAnimation(entity, effect);
+```
+
+---
+
+### Query & Lookup
+
+#### `WarSpriteAnimation* wanim_findAnimation(WarContext* context, WarEntity* entity, StringView name)`
+
+**Purpose:** Find an animation by name on an entity.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Entity to search
+- `name` - Animation name
+
+**Returns:** Pointer to animation, or NULL if not found
+
+**Example:**
+```c
+WarSpriteAnimation* damage = wanim_findAnimation(context, building, "damage_overlay");
+if (damage)
+{
+    logInfo("Damage animation found");
+}
+```
+
+---
+
+#### `bool wanim_containsAnimation(WarContext* context, WarEntity* entity, StringView name)`
+
+**Purpose:** Check if an entity has a specific animation.
+
+**Parameters:**
+- Same as `wanim_findAnimation`
+
+**Returns:** true if animation exists, false otherwise
+
+**Example:**
+```c
+if (wanim_containsAnimation(context, building, "collapse"))
+{
+    // Building is collapsing, don't allow repairs
+}
+```
+
+---
+
+#### `f32 wanim_getAnimationDuration(WarSpriteAnimation* animation)`
+
+**Purpose:** Calculate total playback duration.
+
+**Parameters:**
+- `animation` - Animation to query
+
+**Returns:** Duration in seconds = `frameDelay * frameCount`
+
+**Example:**
+```c
+f32 duration = wanim_getAnimationDuration(explosion);
+// Schedule cleanup or next action after explosion finishes
+scheduleAfterDelay(duration, nextAction);
+```
+
+---
+
+### Removal & Cleanup
+
+#### `void wanim_removeAnimation(WarContext* context, WarEntity* entity, StringView name)`
+
+**Purpose:** Manually remove an animation from an entity.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Entity containing animation
+- `name` - Name of animation to remove
+
+**What it does:**
+- Finds the animation by name
+- Removes it from the animations list
+- Memory is freed
+
+**Example:**
+```c
+// Cancel a damage overlay
+wanim_removeAnimation(context, building, "damage_overlay");
+```
+
+---
+
+#### `void wanim_freeAnimation(WarSpriteAnimation* animation)`
+
+**Purpose:** Free animation memory.
+
+**Parameters:**
+- `animation` - Animation to free
+
+**What it does:**
+- Deallocates the frame list
+- Deallocates the animation struct
+
+**Note:** Called automatically when `FINISHED` status is detected during update. Manual calls are rare.
+
+---
+
+### Update & Playback
+
+#### `void wanim_updateAnimations(WarContext* context)`
+
+**Purpose:** Advance all animations in the game by one frame.
+
+**When to call:** Every game loop frame (called from main game update)
+
+**What it does:**
+1. Iterates all entities
+2. For each entity's animation list, calls `wanim_updateAnimation`
+3. Automatically removes finished non-looping animations
+4. Handles loop delays and auto-removal
+
+**Example:**
+```c
+void wg_updateGame(WarContext* context)
+{
+    // ... other updates ...
+    wanim_updateAnimations(context);  // Advance all animations
+    // ... render ...
+}
+```
+
+**Internal Logic:**
+```
+For each animation:
+  - If FINISHED and not looping → remove and continue
+  - Set status to RUNNING
+  - If in loop delay → decrement, return (wait)
+  - Calculate progress: dt = deltaTime / totalDuration
+  - Scale dt by map speed
+  - Increment animTime by dt
+  - If animTime >= 1.0 → FINISHED
+    - If looping → reset and set loopDelay countdown
+    - Else → will be removed next update
+```
+
+---
+
+## Pre-Made Animation Factories
+
+The animation system includes factory functions for common visual effects. These handle all frame setup and positioning automatically.
+
+### Building Damage Overlay
+
+#### `WarSpriteAnimation* wanim_createDamageAnimation(WarContext* context, WarEntity* entity, String name, int damageLevel)`
+
+**Purpose:** Create a damage indicator overlay on a building.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Building entity to damage
+- `name` - Identifier for this effect
+- `damageLevel` - 1 or 2 (damage level determines sprite)
+
+**What it does:**
+- Creates animation with 4 frames (damage indicator phases)
+- Loops continuously
+- Positions at the building's sprite center
+- Frame delay: 0.2s (5 FPS, slow pulsing)
+- **Automatically attached to entity**
+
+**Returns:** The animation (so you can remove it later if needed)
+
+**Example:**
+```c
+// Show damage on building
+wanim_createDamageAnimation(context, damaged_building, "damage_lvl1", 1);
+
+// Later, when healed
+wanim_removeAnimation(context, damaged_building, "damage_lvl1");
+```
+
+---
+
+### Building Collapse
+
+#### `WarSpriteAnimation* wanim_createCollapseAnimation(WarContext* context, WarEntity* entity, String name)`
+
+**Purpose:** Play a building collapse/explosion effect.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Building to collapse
+- `name` - Identifier
+
+**What it does:**
+- Creates a 17-frame collapse sequence
+- Non-looping (plays once)
+- Frame delay: 0.1s (10 FPS)
+- Dynamically scales animation to match building size
+- Calculates offset so explosion is centered on building
+- **Automatically attached to entity**
+
+**Returns:** The animation
+
+**Example:**
+```c
+// Building is destroyed
+wanim_createCollapseAnimation(context, barracks, "collapse_effect");
+// Animation plays, then automatically removed when finished
+```
+
+---
+
+### General Explosions
+
+#### `WarSpriteAnimation* wanim_createExplosionAnimation(WarContext* context, WarEntity* entity, vec2 position)`
+
+**Purpose:** Spawn an explosion effect at a specific world position.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Entity to attach animation to (often a dummy entity or projectile)
+- `position` - World coordinates for explosion center
+
+**What it does:**
+- Creates a 6-frame explosion
+- Non-looping
+- Frame delay: 0.1s
+- Names animation based on position (e.g., "explosion_123.45_67.89")
+- Positions sprite at world coordinates
+- **Automatically attached**
+
+**Returns:** The animation
+
+**Example:**
+```c
+// Catapult shot lands
+vec2 hitPos = vec2f(100.0f, 200.0f);
+wanim_createExplosionAnimation(context, world_entity, hitPos);
+```
+
+---
+
+#### `WarSpriteAnimation* wanim_createRainOfFireExplosionAnimation(WarContext* context, WarEntity* entity, vec2 position)`
+
+**Purpose:** Spawn a "Rain of Fire" spell explosion effect.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Entity to attach to
+- `position` - World coordinates
+
+**What it does:**
+- Creates a 3-frame (frames 3, 4, 5) "rain of fire" explosion
+- Non-looping
+- Frame delay: 0.1s
+- Positioned at world coordinates
+- **Automatically attached**
+
+**Returns:** The animation
+
+**Example:**
+```c
+// Rain of Fire spell cast
+wanim_createRainOfFireExplosionAnimation(context, caster, spellCenter);
+```
+
+---
+
+### Spell Effects
+
+#### `WarSpriteAnimation* wanim_createSpellAnimation(WarContext* context, WarEntity* entity, vec2 position)`
+
+**Purpose:** Display a generic spell cast effect.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Entity to attach to
+- `position` - World coordinates
+
+**What it does:**
+- Creates a 6-frame spell effect
+- Non-looping
+- Frame delay: 0.4s (slower than explosions)
+- Positioned at world coordinates
+- **Automatically attached**
+
+**Returns:** The animation
+
+**Example:**
+```c
+// Fireball spell at target location
+wanim_createSpellAnimation(context, caster, targetPos);
+```
+
+---
+
+#### `WarSpriteAnimation* wanim_createPoisonCloudAnimation(WarContext* context, WarEntity* entity, vec2 position)`
+
+**Purpose:** Create a lingering poison cloud effect.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - Entity to attach to
+- `position` - World coordinates
+
+**What it does:**
+- Creates a 4-frame poison cloud
+- **Loops continuously** (unlike most effects)
+- Frame delay: 0.5s (slow, dreamy animation)
+- Positioned at world coordinates
+- **Automatically attached**
+
+**Returns:** The animation
+
+**Example:**
+```c
+// Poison spell creates cloud at location
+wanim_createPoisonCloudAnimation(context, spell_source, cloudPos);
+// Cloud persists and loops until manually removed
+```
+
+---
+
+## Integration Points
+
+### Game Loop
+
+```c
+void wg_updateGame(WarContext* context)
+{
+    // ... update game logic ...
+    
+    // Update all animations (must be called every frame)
+    wanim_updateAnimations(context);
+    
+    // Render everything (animations rendered based on their status/frames)
+    wr_render(context);
+}
+```
+
+### Rendering Integration
+
+The animation system provides frame and positioning data. Rendering code uses:
+- `animation->sprite.frameIndex` - which frame to display
+- `animation->offset` - position offset
+- `animation->scale` - scaling factor
+
+The render system draws animations **on top of** the entity's normal sprite, allowing layering.
+
+### Example: Projectile Impact
+
+```c
+// Projectile hits target
+void handleProjectileImpact(WarContext* context, WarProjectile* proj, WarEntity* target)
+{
+    // Deal damage
+    wu_damageUnit(target, proj->damage);
+    
+    // Create visual feedback
+    if (proj->type == WAR_PROJECTILE_FIREBALL)
+    {
+        wanim_createExplosionAnimation(context, target, proj->position);
+    }
+    else if (proj->type == WAR_PROJECTILE_ARROW)
+    {
+        wanim_createSpellAnimation(context, target, proj->position);
+    }
+    
+    // Remove projectile
+    we_destroyEntity(context, proj->entity);
+}
+```
+
+### Example: Building Destruction
+
+```c
+// Building health reaches zero
+void handleBuildingDeath(WarContext* context, WarEntity* building)
+{
+    // Create collapse effect
+    wanim_createCollapseAnimation(context, building, "collapse");
+    
+    // Remove after animation completes
+    // (automatic: animation is removed when FINISHED)
+}
+```
+
+---
+
+## Animation Lifecycle
+
+### Timeline
+
+```
+1. Created
+   wanim_createAnimation() or wanim_createDamageAnimation(), etc.
+   Status: NOT_STARTED
+   animTime: 0
+
+2. Attached
+   wanim_addAnimation(entity, animation)
+   Now managed by entity's animations component
+
+3. First Update
+   wanim_updateAnimations() called
+   Status: RUNNING
+   First frame displayed
+
+4. Playing
+   Each update increments animTime
+   Frame index determined by animTime * frameCount
+   animTime goes from 0 to 1
+
+5. Completion
+   animTime >= 1.0
+   Status: FINISHED
+   If loop: restart with loopDelay
+   If no loop: marked for removal
+
+6. Cleanup
+   Next wanim_updateAnimations() call
+   Animation removed from entity
+   Memory freed
+```
+
+---
+
+## Performance Considerations
+
+### Memory
+- Each animation: ~100-200 bytes base + frame list
+- Frame list: 4 bytes per frame × count
+- Example: 6-frame explosion = ~125 + 24 = ~150 bytes
+
+### CPU
+- `wanim_updateAnimations()` is O(entities × animations per entity)
+- Update is trivial: counter increment, no allocations
+- Profiled with Tracy (see code: `TracyCZoneN`)
+
+### Typical Scene Load
+- Explosions: 50-100 active simultaneous → minimal impact
+- Damage overlays on buildings: constant, low cost
+- Spell effects: burst of animations during battles
+
+---
+
+## Common Patterns
+
+### Pattern 1: Simple Explosion on Impact
+
+```c
+vec2 impact_pos = projectile->position;
+wanim_createExplosionAnimation(context, dummy_entity, impact_pos);
+// That's it! Animation plays automatically
+```
+
+### Pattern 2: Damage Feedback Loop
+
+```c
+// Building takes damage
+wu_takeDamage(building, 20);
+
+// Show damage state
+int damageLevel = building->health < 50 ? 2 : 1;
+wanim_createDamageAnimation(context, building, "damage_indicator", damageLevel);
+
+// Later, building repaired
+wu_repair(building, 30);
+wanim_removeAnimation(context, building, "damage_indicator");
+```
+
+### Pattern 3: Multi-Frame Custom Effect
+
+```c
+WarSpriteAnimation* custom = wanim_createAnimation(
+    context,
+    "my_effect",
+    customSprite,
+    0.15f,  // 150ms per frame
+    false   // Play once
+);
+
+// Add frames manually
+wanim_addAnimationFramesRange(custom, 0, 10);      // Frames 0-10
+wanim_addAnimationFramesRange(custom, 9, 0);       // Reverse: 9-0 (ping-pong)
+
+// Position and attach
+custom->offset = vec2f(50.0f, 30.0f);
+custom->scale = vec2f(2.0f, 2.0f);
+wanim_addAnimation(building, custom);
+```
+
+### Pattern 4: Looping Environmental Effect
+
+```c
+// Poison cloud at a location (loops indefinitely)
+WarSpriteAnimation* cloud = wanim_createPoisonCloudAnimation(
+    context,
+    world_entity,
+    poison_center
+);
+
+// Later, when effect expires or area clears
+wanim_removeAnimation(context, world_entity, "poison_cloud_...");
+```
+
+### Pattern 5: Check Animation Status
+
+```c
+// Only allow repairs while NOT collapsing
+if (!wanim_containsAnimation(context, building, "collapse"))
+{
+    allowRepairs(building);
+}
+else
+{
+    blockRepairs(building);  // Building is collapsing
+}
+```
+
+---
+
+## Comparison: Animation vs Action Systems
+
+| Aspect | Animation System | Action System |
+|--------|------------------|---------------|
+| **Purpose** | Temporary effects | Unit state/animation |
+| **Duration** | Seconds (typically) | Indefinite loops |
+| **Integration** | Overlay on entity | Core unit behavior |
+| **Multiple Instances** | Yes (multiple on one entity) | One active per unit |
+| **Looping** | Optional, with delay | Built-in via FSM |
+| **Directional** | No (static orientation) | Yes (8 directions) |
+| **Removal** | Automatic when finished | Via FSM state change |
+| **Use Case** | Explosions, damage, spells | Walk, attack, idle |
+
+**When to use Animation System:**
+- One-off visual effects
+- Temporary overlays
+- Environmental effects
+- Spell/ability visuals
+- Building destruction
+
+**When to use Action System:**
+- Continuous unit animations
+- FSM-driven behaviors
+- Animation tied to game state
+- Directional playback
+
+---
+
+## Extension Points
+
+### Adding a New Pre-Made Effect
+
+1. Create a factory function in `war_animations.c`:
+
+```c
+WarSpriteAnimation* wanim_createLightningAnimation(WarContext* context, WarEntity* entity, vec2 position)
+{
+    WarSpriteResourceRef spriteResourceRef = imageResourceRef(WAR_LIGHTNING_RESOURCE);
+    WarSprite sprite = wspr_createSpriteFromResourceIndex(context, spriteResourceRef);
+    
+    String name = wstr_make();
+    wstr_appendFormat(&name, "lightning_%.2f_%.2f", position.x, position.y);
+    
+    WarSpriteAnimation* anim = wanim_createAnimation(context, name, sprite, 0.08f, false);
+    
+    // Positioning and frame setup...
+    wanim_addAnimationFramesRange(anim, 0, 7);
+    
+    wanim_addAnimation(entity, anim);
+    return anim;
+}
+```
+
+2. Add declaration to `war_animations.h`:
+
+```c
+WarSpriteAnimation* wanim_createLightningAnimation(WarContext* context, WarEntity* entity, vec2 position);
+```
+
+3. Call from game logic:
+
+```c
+wanim_createLightningAnimation(context, caster, target_pos);
+```
+
+---
+
+## Summary
+
+The Animation System provides:
+- ✅ **Flexible sprite sequencing** - Any sprite can be a multi-frame animation
+- ✅ **Position & scale control** - Overlay effects anywhere
+- ✅ **Looping with delays** - Natural pause between loops
+- ✅ **Auto-cleanup** - Finished animations self-remove
+- ✅ **Multiple simultaneous effects** - Entity can have many animations
+- ✅ **Pre-built factories** - Common effects ready to use (explosions, spells, damage)
+- ✅ **Delta-time independent** - Frame-rate agnostic timing
+- ✅ **Performance optimized** - O(n) per entity per frame
+
+All animations flow through `wanim_createAnimation()` (or factories), `wanim_addAnimation()` (attach), and `wanim_updateAnimations()` (advance), making the system simple, efficient, and easy to extend for new effects.

--- a/docs/COMMANDS_SYSTEM.md
+++ b/docs/COMMANDS_SYSTEM.md
@@ -1,0 +1,830 @@
+# War1-C Commands System Documentation
+
+## Overview
+
+The Commands System is the **interface between player input and game state changes**. It translates player actions (clicking on units, right-clicking the map, pressing ability hotkeys) into high-level commands that affect units, buildings, and gameplay progression.
+
+Commands are **asynchronous and batched**: the player issues commands through the UI, commands are queued, and they're executed when ready (respecting cooldowns, resource costs, and prerequisites). This design enables:
+
+- **Multi-unit operations** - "Select 5 footmen, move to point X" applies to all selected
+- **Deferred execution** - Commands respect prerequisites (enough resources, mana, valid targets)
+- **Sound feedback** - Acknowledgement sounds and error handling
+- **Formation preservation** - Moving multiple units maintains their formation
+- **State transitions** - Commands drive the FSM to appropriate unit behaviors
+
+Examples:
+- **Movement**: Player clicks terrain → all selected units move there in formation
+- **Training**: Player clicks "Train Footman" → barracks queues unit if resources permit
+- **Casting**: Player clicks "Rain of Fire" + target tile → conjurer casts spell
+- **Building**: Player clicks "Build Farm" + target tile → peasant walks there and constructs
+
+---
+
+## Architecture
+
+### Two-Tier Command Processing
+
+The system has two processing levels:
+
+1. **Command Registration** (`wcmd_train*`, `wcmd_cast*`, etc.)
+   - Called by UI buttons/hotkeys
+   - Stores command type in `map->command`
+   - Lightweight, no validation yet
+
+2. **Command Execution** (`wcmd_executeCommand`)
+   - Called from game loop
+   - Validates command feasibility
+   - Applies state changes
+   - Affects all selected units
+   - Plays audio feedback
+
+### Command Flow
+
+```
+User Input (UI button click)
+  ↓
+wcmd_trainFootman(context, entity)  [or similar wcmd_* function]
+  ↓
+map->command.type = WAR_COMMAND_TRAIN_FOOTMAN
+  ↓
+[Next game frame]
+  ↓
+wcmd_executeCommand(context)  [main game loop]
+  ↓
+Validate command (check resources, mana, unit state, etc.)
+  ↓
+For each selected unit:
+  - Create appropriate FSM state
+  - Queue or execute the action
+  - Play acknowledgement sound
+```
+
+---
+
+## Key Types
+
+### `WarUnitCommandType` - Command Categories
+
+```c
+typedef enum _WarUnitCommandType
+{
+    // Basic unit actions
+    WAR_COMMAND_NONE,
+    WAR_COMMAND_MOVE,        // Move to position
+    WAR_COMMAND_STOP,        // Stop current action
+    WAR_COMMAND_HARVEST,     // Gather resources (gold/wood)
+    WAR_COMMAND_DELIVER,     // Deliver resources to town hall
+    WAR_COMMAND_REPAIR,      // Repair building
+    WAR_COMMAND_ATTACK,      // Attack unit/building
+
+    // Unit training
+    WAR_COMMAND_TRAIN_FOOTMAN,
+    WAR_COMMAND_TRAIN_GRUNT,
+    WAR_COMMAND_TRAIN_PEASANT,
+    WAR_COMMAND_TRAIN_PEON,
+    WAR_COMMAND_TRAIN_CATAPULT_HUMANS,
+    WAR_COMMAND_TRAIN_CATAPULT_ORCS,
+    // ... 8 more unit types ...
+
+    // Spell casting
+    WAR_COMMAND_SPELL_HEALING,
+    WAR_COMMAND_SPELL_FAR_SIGHT,
+    WAR_COMMAND_SPELL_INVISIBILITY,
+    WAR_COMMAND_SPELL_RAIN_OF_FIRE,
+    WAR_COMMAND_SPELL_POISON_CLOUD,
+    WAR_COMMAND_SPELL_RAISE_DEAD,
+    WAR_COMMAND_SPELL_DARK_VISION,
+    WAR_COMMAND_SPELL_UNHOLY_ARMOR,
+
+    // Summoning
+    WAR_COMMAND_SUMMON_SPIDER,
+    WAR_COMMAND_SUMMON_SCORPION,
+    WAR_COMMAND_SUMMON_DAEMON,
+    WAR_COMMAND_SUMMON_WATER_ELEMENTAL,
+
+    // Building construction
+    WAR_COMMAND_BUILD_BASIC,
+    WAR_COMMAND_BUILD_ADVANCED,
+    WAR_COMMAND_BUILD_FARM_HUMANS,
+    WAR_COMMAND_BUILD_FARM_ORCS,
+    // ... 16 more building types ...
+    WAR_COMMAND_BUILD_ROAD,
+    WAR_COMMAND_BUILD_WALL,
+
+    // Unit/spell upgrades
+    WAR_COMMAND_UPGRADE_SWORDS,
+    WAR_COMMAND_UPGRADE_AXES,
+    // ... 18 more upgrades ...
+
+    // Special
+    WAR_COMMAND_CANCEL,
+
+    WAR_COMMAND_COUNT
+} WarUnitCommandType;
+```
+
+### `WarUnitCommand` - Command Payload
+
+```c
+struct _WarUnitCommand
+{
+    WarUnitCommandType type;  // What to do
+
+    union                     // Type-specific parameters
+    {
+        struct
+        {
+            WarUnitType unitToTrain;   // Which unit to create
+            WarUnitType buildingUnit;  // Where to create it (building type)
+        } train;
+
+        struct
+        {
+            WarUpgradeType upgradeToBuild;  // Which upgrade to research
+            WarUnitType buildingUnit;       // Which building researches it
+        } upgrade;
+
+        struct
+        {
+            WarUnitType buildingToBuild;    // Which building to construct
+        } build;
+    };
+};
+```
+
+---
+
+## API Reference
+
+### High-Level Command Functions
+
+These are called by the UI when the player clicks a button or presses a hotkey. They simply store the command type (and metadata) for later execution.
+
+#### Unit Movement
+
+```c
+void move(WarContext* context, WarEntity* entity)
+```
+**Purpose:** Queue a move command to a specific position.
+
+**How it's used:**
+```c
+// Player right-clicks the map
+wcmd_executeMoveCommand(context, clickedPosition);
+```
+
+**What happens:**
+- All selected units move to the position
+- Formation is preserved (relative positions maintained)
+- With SHIFT held, adds waypoint to current move queue
+- Plays acknowledgement sound
+
+---
+
+#### Unit Actions
+
+```c
+void wcmd_stop(WarContext* context, WarEntity* entity)
+```
+**Purpose:** Stop all current actions.
+
+```c
+void wcmd_harvest(WarContext* context, WarEntity* entity)
+```
+**Purpose:** Harvest resources (gold/wood).
+
+**What happens:**
+- Workers go to resource location
+- If carrying resources, deliver first
+- Loops until manually stopped
+
+```c
+void attack(WarContext* context, WarEntity* entity)
+```
+**Purpose:** Attack target unit/building.
+
+**What happens:**
+- Selected units engage target
+- Combat until target dies or command cancelled
+- Applies to friendly, hostile detection
+
+```c
+void repair(WarContext* context, WarEntity* entity)
+```
+**Purpose:** Repair damaged building.
+
+**What happens:**
+- Workers walk to building
+- Repair animation plays
+- Building health increases
+- Workers can be interrupted
+
+---
+
+#### Training Units
+
+```c
+void wcmd_trainFootman(WarContext* context, WarEntity* entity)
+void wcmd_trainGrunt(WarContext* context, WarEntity* entity)
+void wcmd_trainPeasant(WarContext* context, WarEntity* entity)
+// ... and 11 more unit types
+```
+
+**Purpose:** Queue unit training in a barracks/training building.
+
+**Parameters:**
+- `context` - Game context
+- `entity` - (unused, for API consistency)
+
+**What happens:**
+1. Check if barracks has required resources
+2. Deduct resources from player pool
+3. Start training timer
+4. Create unit when complete
+5. Play acknowledgement sound if successful
+
+**Example:**
+```c
+// Player clicks "Train Footman" button
+wcmd_trainFootman(context, NULL);
+
+// Implementation sets:
+// map->command.type = WAR_COMMAND_TRAIN_FOOTMAN
+// Later execution validates and creates unit
+```
+
+**Training is tracked per building:**
+- Barracks can queue multiple units
+- Each unit takes time and resources
+- Units are created one at a time
+
+---
+
+#### Building Construction
+
+```c
+void wcmd_buildFarmHumans(WarContext* context, WarEntity* entity)
+void wcmd_buildBarracksHumans(WarContext* context, WarEntity* entity)
+// ... and 16 more building types
+```
+
+**Purpose:** Queue building placement mode.
+
+**What happens:**
+1. Stores build command in map state
+2. UI enters "building placement" mode
+3. Player clicks terrain to place
+4. Peasant/Peon walks to location
+5. Construction begins
+6. Building health increases during construction
+
+**Construction by workers:**
+- Workers carry construction materials
+- Multiple workers can work on same building
+- Accelerates construction
+- Blocks workers from other tasks
+
+```c
+void wcmd_buildWall(WarContext* context, WarEntity* entity)
+void wcmd_buildRoad(WarContext* context, WarEntity* entity)
+```
+
+**Purpose:** Begin wall/road placement.
+
+**What happens:**
+- UI enters placement mode
+- Player clicks tiles to place wall/road pieces
+- Pieces automatically connect (T-junctions, crosses, etc.)
+- Completed instantly (no construction time)
+
+---
+
+#### Spell Casting
+
+```c
+void wcmd_castRainOfFire(WarContext* context, WarEntity* entity)
+void wcmd_castPoisonCloud(WarContext* context, WarEntity* entity)
+void wcmd_castHeal(WarContext* context, WarEntity* entity)
+void wcmd_castFarSight(WarContext* context, WarEntity* entity)
+// ... more spells
+```
+
+**Purpose:** Queue spell casting.
+
+**What happens:**
+1. Validates casting unit has mana
+2. Creates CAST state for selected mages
+3. Mage walks toward target (if out of range)
+4. Animates casting
+5. Spell effect triggers at full cast
+6. Deducts mana
+7. Cooldown period
+
+**Target vs Area spells:**
+- **Targeted** (Heal, Invisibility): Click on unit
+- **Area** (Rain of Fire, Poison Cloud): Click on terrain
+- **Instant** (Raise Dead): Cast at location
+
+```c
+void wcmd_castInvisibility(WarContext* context, WarEntity* entity)
+```
+Makes selected units invisible (if Cleric/Necrolyte selected).
+
+```c
+void wcmd_castUnHolyArmor(WarContext* context, WarEntity* entity)
+```
+Buffs selected units (damage reduction).
+
+```c
+void wcmd_castFarSight(WarContext* context, WarEntity* entity)
+```
+Temporarily reveals distant map area.
+
+---
+
+#### Summoning
+
+```c
+void wcmd_summonSpider(WarContext* context, WarEntity* entity)
+void wcmd_summonScorpion(WarContext* context, WarEntity* entity)
+void wcmd_summonDaemon(WarContext* context, WarEntity* entity)
+void wcmd_summonWaterElemental(WarContext* context, WarEntity* entity)
+```
+
+**Purpose:** Summon creature as Conjurer/Warlock.
+
+**What happens:**
+1. Validates unit is Conjurer/Warlock
+2. Checks mana for each summon
+3. Spawns creature at mage position (randomized empty spot)
+4. Creature can be controlled like normal unit
+5. Creature disappears when killed
+6. Plays spell cast effect
+
+**Cost:** Each summon costs mana (can summon multiple per cast)
+
+---
+
+#### Upgrades
+
+```c
+void wcmd_upgradeSwords(WarContext* context, WarEntity* entity)
+void wcmd_upgradeHumanShields(WarContext* context, WarEntity* entity)
+void wcmd_upgradeHorses(WarContext* context, WarEntity* entity)
+// ... 17 more upgrades
+```
+
+**Purpose:** Research technology in appropriate building.
+
+**What happens:**
+1. Validates building exists and is idle
+2. Deducts resources
+3. Plays "research" animation
+4. After duration, upgrade complete
+5. All matching units gain bonus (damage, armor, speed, etc.)
+6. UI updates to reflect new capabilities
+
+**Upgrade types:**
+- **Weapon upgrades** (Swords, Axes, Arrows, Spears) → More damage
+- **Armor upgrades** (Shields) → More armor
+- **Unit upgrades** (Horses, Wolves, Scorpions, Spiders) → Better mounts/summons
+- **Spell upgrades** (Rain of Fire, Poison Cloud, Water Elemental, Daemon) → More powerful spells
+- **Ability upgrades** (Healing, Raise Dead, Invisibility, Unholy Armor, Far Sight, Dark Vision)
+
+---
+
+### Execution Functions
+
+These low-level functions handle the actual command execution. Called from the main game loop.
+
+#### `bool wcmd_executeCommand(WarContext* context)`
+
+**Purpose:** Process the queued command.
+
+**Parameters:**
+- `context` - Game context
+
+**Returns:** true if command was processed, false if no command pending
+
+**What it does:**
+1. Checks if a command is queued
+2. Validates all preconditions (resources, mana, valid targets, unit states)
+3. For each selected unit, executes command
+4. Plays audio feedback (success or error)
+5. Clears command after execution
+
+**Called every frame** from the main game loop.
+
+**Example flow:**
+```c
+// Game loop
+void wg_updateGame(WarContext* context)
+{
+    // ... other updates ...
+    wcmd_executeCommand(context);  // Execute queued command
+    // ... continue ...
+}
+```
+
+---
+
+#### Execute Unit Commands
+
+```c
+void wcmd_executeMoveCommand(WarContext* context, vec2 targetPoint)
+void wcmd_executeFollowCommand(WarContext* context, WarEntity* targetEntity)
+void wcmd_executeStopCommand(WarContext* context)
+void wcmd_executeHarvestCommand(WarContext* context, WarEntity* targetEntity, vec2 targetTile)
+void wcmd_executeDeliverCommand(WarContext* context, WarEntity* targetEntity)
+void wcmd_executeRepairCommand(WarContext* context, WarEntity* targetEntity)
+void wcmd_executeAttackCommand(WarContext* context, WarEntity* targetEntity, vec2 targetTile)
+```
+
+**Purpose:** Execute low-level unit actions.
+
+**Parameters vary by command:**
+- Movement: target position
+- Attack/Repair: target entity
+- Harvesting: target resource and position
+
+**What they do:**
+- Create appropriate FSM state for each selected unit
+- Queue the state change
+- Filter units (only friendly, only valid types)
+- Play acknowledgement sound
+
+**Formation Handling:**
+Movement preserves formation:
+```c
+// Calculate bounding box of selected units
+rect bbox = ...;
+
+// For each unit, calculate offset relative to bbox
+// Move unit to target position + offset
+```
+
+---
+
+#### Execute Spell Commands
+
+```c
+void wcmd_executeSummonCommand(WarContext* context, WarUnitCommandType summonType)
+void wcmd_executeRainOfFireCommand(WarContext* context, vec2 targetTile)
+void wcmd_executePoisonCloudCommand(WarContext* context, vec2 targetTile)
+void wcmd_executeHealingCommand(WarContext* context, WarEntity* targetEntity, vec2 targetTile)
+void wcmd_executeInvisiblityCommand(WarContext* context, WarEntity* targetEntity, vec2 targetTile)
+void wcmd_executeUnholyArmorCommand(WarContext* context, WarEntity* targetEntity, vec2 targetTile)
+void wcmd_executeRaiseDeadCommand(WarContext* context, vec2 targetTile)
+void wcmd_executeSightCommand(WarContext* context, vec2 targetTile)
+```
+
+**Purpose:** Execute spell casting.
+
+**Parameters:**
+- Caster selection (operates on selected units)
+- Target entity (for targeted spells) or target tile (for area spells)
+
+**What they do:**
+- Create CAST state for each selected mage
+- Validate mana pool
+- Set target (entity ID or tile position)
+- Animation plays and damage/effect applies
+
+---
+
+## Integration Points
+
+### UI Integration
+
+The command system is driven by UI interactions:
+
+```c
+// User clicks "Move" button or right-clicks map
+// UI layer calls:
+wcmd_executeMoveCommand(context, clickPosition);
+
+// User clicks "Attack" button, selects target
+// UI layer calls:
+wcmd_executeAttackCommand(context, targetEntity, targetTile);
+
+// User presses 'F' for train (or clicks button)
+// UI layer calls:
+wcmd_trainFootman(context, NULL);
+```
+
+### Game Loop Integration
+
+```c
+void wg_updateGame(WarContext* context)
+{
+    // ... update game state ...
+    
+    // Process any queued commands
+    wcmd_executeCommand(context);
+    
+    // ... render ...
+}
+```
+
+### State Machine Integration
+
+Commands create FSM states that drive unit behavior:
+
+```c
+// Move command creates MOVE state
+WarState* moveState = wst_createMoveState(context, entity, ...);
+wst_changeNextState(context, entity, moveState, true, true);
+
+// Attack command creates ATTACK state
+WarState* attackState = wst_createAttackState(context, entity, ...);
+wst_changeNextState(context, entity, attackState, true, true);
+
+// Build command creates BUILD state
+WarState* buildState = wst_createBuildState(context, entity, ...);
+wst_changeNextState(context, entity, buildState, true, true);
+```
+
+The command is ephemeral; the FSM state persists and controls unit behavior until completion.
+
+---
+
+## Command Execution Flow Examples
+
+### Example 1: Move Command
+
+```
+Player right-clicks map at (100, 200)
+  ↓
+wcmd_executeMoveCommand(context, {100, 200})
+  ↓
+For each selected unit:
+  - Calculate bounding box
+  - Compute relative offset
+  - Create MOVE state with target position + offset
+  - Change unit state to MOVE
+  ↓
+Play acknowledgement sound
+  ↓
+[Game loop continues]
+  ↓
+Unit FSM executes MOVE state
+  ↓
+Pathfinding → Movement → Arrival
+```
+
+### Example 2: Train Unit
+
+```
+Player clicks "Train Footman" button
+  ↓
+wcmd_trainFootman(context, NULL)
+  ↓
+map->command.type = WAR_COMMAND_TRAIN_FOOTMAN
+  ↓
+[Next frame: wcmd_executeCommand(context)]
+  ↓
+Check: Does barracks have 600 gold? Yes
+  ↓
+Deduct 600 gold from player
+  ↓
+Start training timer (10 seconds)
+  ↓
+Play acknowledgement sound
+  ↓
+[After 10 seconds]
+  ↓
+Footman spawns at barracks
+  ↓
+Can now be selected and commanded
+```
+
+### Example 3: Cast Spell
+
+```
+Player clicks "Rain of Fire" button
+  ↓
+wcmd_castRainOfFire(context, NULL)
+  ↓
+map->command.type = WAR_COMMAND_SPELL_RAIN_OF_FIRE
+UI enters "spell targeting" mode
+  ↓
+Player clicks target tile
+  ↓
+wcmd_executeRainOfFireCommand(context, targetTile)
+  ↓
+For each selected Conjurer/Warlock:
+  - Check: Mana >= 50? Yes
+  - Create CAST state (spell type = RAIN_OF_FIRE)
+  - Set target position
+  - Change state to CAST
+  ↓
+[FSM executes CAST state]
+  ↓
+Mage walks toward target (if needed)
+  ↓
+Animation plays
+  ↓
+At cast completion:
+  - Spell effect triggers
+  - Rain of fire appears at target
+  - Damage applied to units in area
+  - Mana deducted
+```
+
+### Example 4: Repair Building
+
+```
+Player selects 3 peasants
+Player right-clicks damaged barracks
+  ↓
+wcmd_executeRepairCommand(context, barracks)
+  ↓
+For each selected peasant:
+  - Check: Is peasant friendly? Yes
+  - Check: Is target a building? Yes
+  - Create REPAIR state (target = barracks)
+  - Change state to REPAIR
+  ↓
+[FSM executes REPAIR for each peasant]
+  ↓
+Peasant 1 walks to barracks
+Peasant 2 walks to barracks
+Peasant 3 walks to barracks
+  ↓
+Each plays repair animation at building
+  ↓
+Building health increases
+  ↓
+Repair continues until full health or interrupted
+```
+
+---
+
+## Command Queueing & Shift-Click
+
+**Without SHIFT:**
+- Command replaces current unit orders
+- Unit stops and executes new command
+
+**With SHIFT (Shift+Right-Click):**
+- Command is queued after current action
+- Unit completes current action, then executes queued command
+- Can queue multiple waypoints or actions
+
+```c
+// Without SHIFT: Replace current order
+WarState* moveState = wst_createMoveState(context, entity, ...);
+wst_changeNextState(context, entity, moveState, true, true);  // Replace state
+
+// With SHIFT: Queue waypoint
+if (isKeyPressed(input, WAR_KEY_SHIFT))
+{
+    WarState* moveState = getMoveState(entity);
+    vec2ListAdd(&moveState->move.positions, targetWaypoint);  // Add to queue
+}
+```
+
+---
+
+## Command Validation
+
+Before executing, commands validate:
+
+1. **Unit validity**
+   - Is unit friendly (owned by player)?
+   - Is unit capable of command (e.g., workers for harvest, mages for spells)?
+
+2. **Target validity**
+   - Does target exist?
+   - Is target appropriate for command (e.g., can't attack own units)?
+   - Is target in range?
+
+3. **Resource validation**
+   - Player has gold/wood for training
+   - Unit has mana for spells
+   - Building can be repaired (has health < max)
+
+4. **State validation**
+   - Unit is not dead
+   - Unit is not currently in incompatible state (e.g., can't train while under attack)
+   - Building is constructed (not mid-construction)
+
+5. **Feasibility**
+   - Pathfinding can find route to target
+   - Target location is reachable
+   - Building location is valid (no overlap, terrain passable)
+
+---
+
+## Common Patterns
+
+### Pattern 1: Simple Move/Attack
+
+```c
+// User selects units and right-clicks
+// If terrain clicked: move
+wcmd_executeMoveCommand(context, terrainPos);
+
+// If enemy clicked: attack
+wcmd_executeAttackCommand(context, enemyUnit, enemyPos);
+```
+
+### Pattern 2: Multi-Selection Actions
+
+```c
+// Works on all selected units
+WarMap* map = context->map;
+for (s32 i = 0; i < map->selectedEntities.count; i++)
+{
+    WarEntityId id = map->selectedEntities.items[i];
+    WarEntity* unit = we_findEntity(context, id);
+    
+    if (wu_isFriendlyUnit(context, unit))
+    {
+        // Apply command to this unit
+        WarState* newState = wst_createXxxState(...);
+        wst_changeNextState(context, unit, newState, true, true);
+    }
+}
+```
+
+### Pattern 3: Formation Preservation
+
+```c
+// Calculate bounding box of selected units
+rect bbox = getSelectionBBox(map->selectedEntities);
+
+// For each unit, maintain relative offset
+for (each unit in selection)
+{
+    vec2 relativeOffset = unit->position - bbox.center;
+    vec2 newTarget = targetPos + relativeOffset;
+    // Move unit to newTarget
+}
+```
+
+### Pattern 4: Resource Validation
+
+```c
+// Before executing train command
+WarPlayerInfo* player = &map->players[player_id];
+WarUnitStats* stats = wu_getUnitStats(unitToTrain);
+
+if (player->gold >= stats->cost.gold && 
+    player->wood >= stats->cost.wood)
+{
+    // Deduct and create unit
+    player->gold -= stats->cost.gold;
+    player->wood -= stats->cost.wood;
+    we_createUnit(context, unitToTrain, ...);
+}
+else
+{
+    // Play error sound, show message
+    wa_playErrorSound(context, player);
+}
+```
+
+---
+
+## Performance Considerations
+
+### Efficient Multi-Unit Operations
+
+- Single loop over selected units (not nested searches)
+- Batch pathfinding queries
+- Cache unit capabilities (is worker? is mage?)
+- Defer state creation to dedicated state machine
+
+### Command Queue Depth
+
+- Typically 1 command queued at a time
+- With Shift+Click, up to 10 waypoints per move state
+- No global command queue (per-unit FSM manages order)
+
+### Validation Overhead
+
+- Validation is O(selected units count)
+- Typical selection: 1-20 units
+- Pathfinding: O(map size), done once per move
+- Negligible performance impact
+
+---
+
+## Summary
+
+The Commands System provides:
+- ✅ **Player input translation** - UI clicks → game state changes
+- ✅ **Batched multi-unit operations** - Select 10 units, command all simultaneously
+- ✅ **Formation preservation** - Units maintain relative positions
+- ✅ **Validation & error handling** - Checks resources, mana, targets, feasibility
+- ✅ **Audio feedback** - Acknowledgement or error sounds
+- ✅ **State machine integration** - Commands drive FSM behaviors
+- ✅ **Queuing support** - Shift+Click for waypoint chains
+- ✅ **Resource management** - Gold, wood, mana deduction with verification
+
+All commands flow through two APIs:
+1. **Registration** (`wcmd_trainFootman()`, `wcmd_castRainOfFire()`, etc.) - Lightweight
+2. **Execution** (`wcmd_executeCommand()`, `wcmd_execute*Command()`) - Validation & application
+
+The system is extensible: new commands add one registration function and one execution function.

--- a/src/war_actions.c
+++ b/src/war_actions.c
@@ -80,8 +80,6 @@ static WarUnitActionDef createWalkActionDef(s32 nframes, s32 frames[], s32 walkS
 
     s32 halfIndex = nframes % 2 == 0 ? nframes / 2 : (nframes + 1) / 2;
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     // This code convert the frames sequence in this WAR_ACTION_STEP_FRAME sequence.
     // (this code is ported from the War1gus project, built with the Stratagus engine)
     //
@@ -121,7 +119,6 @@ static WarUnitActionDef createWalkActionDef(s32 nframes, s32 frames[], s32 walkS
         for(s32 i = 0; i < halfIndex; i++)
         {
             addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
-            addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
             addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
             actionFrames--;
         }
@@ -129,20 +126,17 @@ static WarUnitActionDef createWalkActionDef(s32 nframes, s32 frames[], s32 walkS
         for(s32 i = halfIndex - 2; i >= 0; i--)
         {
             addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
-            addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
             addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
             actionFrames--;
         }
 
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
-        addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
         actionFrames--;
 
         for(s32 i = 0; i < halfIndex; i++)
         {
             addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[nframes - 1 - i]);
-            addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
             addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
             actionFrames--;
         }
@@ -150,18 +144,15 @@ static WarUnitActionDef createWalkActionDef(s32 nframes, s32 frames[], s32 walkS
         for(s32 i = 1 + nframes - halfIndex; i < nframes; i++)
         {
             addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
-            addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
             addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
             actionFrames--;
         }
 
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
-        addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
         actionFrames--;
     }
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
@@ -172,16 +163,13 @@ static WarUnitActionDef createWalkActionDef(s32 nframes, s32 frames[], s32 walkS
 static WarUnitActionDef createLinearWalkActionDef(s32 framesCount, s32 frames[], bool directional, s32 walkSpeed)
 {
     WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_WALK, directional, true);
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
 
     for(s32 i = 0; i < framesCount; i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
-        addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
     }
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
@@ -194,8 +182,6 @@ static WarUnitActionDef createAttackActionDef(s32 nframes, s32 frames[], s32 att
 
     s32 halfIndex = nframes%2 == 0 ? nframes/2 : (nframes+1)/2;
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     for(s32 i = 0; i < nframes; i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
@@ -213,8 +199,6 @@ static WarUnitActionDef createAttackActionDef(s32 nframes, s32 frames[], s32 att
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, (5 - nframes) * attackSpeed);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, coolOffTime);
-
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
@@ -227,8 +211,6 @@ static WarUnitActionDef createRepairActionDef(s32 nframes, s32 frames[], s32 att
 
     s32 halfIndex = nframes%2 == 0 ? nframes/2 : (nframes+1)/2;
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     for(s32 i = 0; i < nframes; i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
@@ -246,8 +228,6 @@ static WarUnitActionDef createRepairActionDef(s32 nframes, s32 frames[], s32 att
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, (5 - nframes) * attackSpeed);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, coolOffTime);
-
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
@@ -260,7 +240,6 @@ static WarUnitActionDef createHarvestActionDef(s32 nframes, s32 frames[], s32 ha
 
     s32 halfIndex = nframes%2 == 0 ? nframes/2 : (nframes+1)/2;
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 5);
 
     for(s32 i = 0; i < nframes; i++)
@@ -280,8 +259,6 @@ static WarUnitActionDef createHarvestActionDef(s32 nframes, s32 frames[], s32 ha
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, (5 - nframes) * harvestSpeed);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, coolOffTime);
-
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
@@ -292,8 +269,6 @@ static WarUnitActionDef createDeathActionDef(s32 nframes, s32 frames[], s32 wait
 {
     WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_DEATH, directional, true);
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     for(s32 i = 0; i < nframes; i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
@@ -303,7 +278,6 @@ static WarUnitActionDef createDeathActionDef(s32 nframes, s32 frames[], s32 wait
     if (doWait101Step)
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 101);
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
     return def;
@@ -313,15 +287,12 @@ static WarUnitActionDef createBuildActionDef(s32 nframes, s32 frames[], s32 wait
 {
     WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_BUILD, false, false);
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     for(s32 i = 0; i < nframes; i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, waitTime);
     }
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
     return def;
@@ -331,15 +302,12 @@ static WarUnitActionDef createIdleActionDef(s32 nframes, s32 frames[], s32 waitT
 {
     WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_IDLE, directional, true);
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     for(s32 i = 0; i < nframes; i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, frames[i]);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, waitTime);
     }
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
     return def;
@@ -358,7 +326,6 @@ static WarUnitActionDef createSpiderScorpionDeathActionDef(s32 framesCount, s32 
     // Scorpions and Spiders have distinct wait times than other units,
     // so a custom death action is built for those cases
     WarUnitActionDef deathDef = createUnitActionDef(WAR_ACTION_TYPE_DEATH, directional, true);
-    addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_FRAME, frames[0]);
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_WAIT, waitTime);
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_FRAME, frames[1]);
@@ -370,7 +337,6 @@ static WarUnitActionDef createSpiderScorpionDeathActionDef(s32 framesCount, s32 
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_FRAME, frames[4]);
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_WAIT, waitTime);
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_WAIT, 101);
-    addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&deathDef, WAR_ACTION_STEP_WAIT, 1);
     return deathDef;
 }
@@ -378,17 +344,14 @@ static WarUnitActionDef createSpiderScorpionDeathActionDef(s32 framesCount, s32 
 static WarUnitActionDef createSlimeWalkActionDef(bool directional, s32 walkSpeed)
 {
     WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_WALK, directional, true);
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
 
     s32 walkFrames[] = {15, 30, 45, 55, 65, 0};
     for(s32 i = 0; i < arrayLength(walkFrames); i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, walkFrames[i]);
-        addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
     }
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 15);
 
@@ -399,17 +362,13 @@ static WarUnitActionDef createFireElementalWalkActionDef(bool directional, s32 w
 {
     WarUnitActionDef def = createUnitActionDef(WAR_ACTION_TYPE_WALK, directional, true);
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_BEGIN);
-
     s32 walkFrames[] = {10, 20, 30, 40, 50, 0};
     for(s32 i = 0; i < arrayLength(walkFrames); i++)
     {
         addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, walkFrames[i]);
-        addUnitActionDefStep(&def, WAR_ACTION_STEP_MOVE, 4);
         addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, walkSpeed);
     }
 
-    addUnitActionDefStep(&def, WAR_ACTION_STEP_UNBREAKABLE, WAR_UNBREAKABLE_END);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_FRAME, 0);
     addUnitActionDefStep(&def, WAR_ACTION_STEP_WAIT, 1);
 
@@ -1007,7 +966,14 @@ void wact_initUnitActionDefs(void)
     initOrcCorpseActionDefs();
 }
 
- void wact_addUnitActions(WarEntity* entity)
+bool wact_equalsActionStep(const WarUnitActionStep step1, const WarUnitActionStep step2)
+{
+    return step1.type == step2.type && step1.param == step2.param;
+}
+
+shlDefineList(WarUnitActionStepList, WarUnitActionStep)
+
+void wact_addUnitActions(WarEntity* entity)
 {
     WarUnitComponent* unit = &entity->unit;
 
@@ -1015,7 +981,6 @@ void wact_initUnitActionDefs(void)
     {
         WarUnitAction* action = &unit->actions[i];
         action->status = WAR_ACTION_NOT_STARTED;
-        action->unbreakable = false;
         action->scale = 1.0f;
         action->waitCount = 0;
         action->stepIndex = -1;
@@ -1145,16 +1110,6 @@ void wact_updateAction(WarContext* context, WarEntity* entity)
     {
         switch (step.type)
         {
-            case WAR_ACTION_STEP_UNBREAKABLE:
-            {
-                if (step.param == WAR_UNBREAKABLE_BEGIN)
-                    action->unbreakable = true;
-                else if(step.param == WAR_UNBREAKABLE_END)
-                    action->unbreakable = false;
-
-                break;
-            }
-
             case WAR_ACTION_STEP_FRAME:
             {
                 s32 frameIndex = step.param;
@@ -1183,19 +1138,11 @@ void wact_updateAction(WarContext* context, WarEntity* entity)
                 sprite->frameIndex = frameIndex;
                 break;
             }
-
-            case WAR_ACTION_STEP_MOVE:
-            {
-                action->lastActionStep = WAR_ACTION_STEP_MOVE;
-                break;
-            }
-
             case WAR_ACTION_STEP_ATTACK:
             {
                 action->lastActionStep = WAR_ACTION_STEP_ATTACK;
                 break;
             }
-
             case WAR_ACTION_STEP_SOUND_SWORD:
             case WAR_ACTION_STEP_SOUND_FIST:
             case WAR_ACTION_STEP_SOUND_FIREBALL:
@@ -1207,7 +1154,6 @@ void wact_updateAction(WarContext* context, WarEntity* entity)
                 action->lastSoundStep = step.type;
                 break;
             }
-
             default:
             {
                 break;

--- a/src/war_actions.h
+++ b/src/war_actions.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "shl/list.h"
+
 #include "war_fwd.h"
 #include "war_math.h"
 
@@ -11,15 +13,11 @@ struct _WarUnitActionStep
 
 #define WarUnitActionStepEmpty (WarUnitActionStep){WAR_ACTION_STEP_NONE}
 
-bool equalsActionStep(const WarUnitActionStep step1, const WarUnitActionStep step2)
-{
-    return step1.type == step2.type && step1.param == step2.param;
-}
+bool wact_equalsActionStep(const WarUnitActionStep step1, const WarUnitActionStep step2);
 
 shlDeclareList(WarUnitActionStepList, WarUnitActionStep)
-shlDefineList(WarUnitActionStepList, WarUnitActionStep)
 
-#define WarUnitActionStepListDefaultOptions (WarUnitActionStepListOptions){WarUnitActionStepEmpty, equalsActionStep, NULL}
+#define WarUnitActionStepListDefaultOptions (WarUnitActionStepListOptions){WarUnitActionStepEmpty, wact_equalsActionStep, NULL}
 
 struct _WarUnitActionDef
 {
@@ -32,7 +30,6 @@ struct _WarUnitActionDef
 struct _WarUnitAction
 {
     WarUnitActionStatus status;
-    bool unbreakable;
     f32 scale;
     f32 waitCount;
     s32 stepIndex;

--- a/src/war_ai.h
+++ b/src/war_ai.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "shl/list.h"
 #include "shl/queue.h"
 
 #include "war_units.h"

--- a/src/war_animations.h
+++ b/src/war_animations.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "shl/list.h"
+
 #include "common.h"
 #include "war_sprites.h"
 

--- a/src/war_entities.h
+++ b/src/war_entities.h
@@ -1,7 +1,9 @@
 ﻿#pragma once
 
 #include "shl/memzone.h"
+#include "shl/list.h"
 #include "shl/set.h"
+#include "shl/map.h"
 
 #include "common.h"
 #include "war.h"

--- a/src/war_enums.h
+++ b/src/war_enums.h
@@ -597,10 +597,8 @@ typedef enum _WarTreeTileType
 typedef enum _WarUnitActionStepType
 {
     WAR_ACTION_STEP_NONE,
-    WAR_ACTION_STEP_UNBREAKABLE,
     WAR_ACTION_STEP_FRAME,
     WAR_ACTION_STEP_WAIT,
-    WAR_ACTION_STEP_MOVE,
     WAR_ACTION_STEP_ATTACK,
     WAR_ACTION_STEP_SOUND_SWORD,
     WAR_ACTION_STEP_SOUND_FIST,
@@ -610,12 +608,6 @@ typedef enum _WarUnitActionStepType
     WAR_ACTION_STEP_SOUND_ARROW,
     WAR_ACTION_STEP_SOUND_LIGHTNING,
 } WarUnitActionStepType;
-
-typedef enum _WarUnbreakableParam
-{
-    WAR_UNBREAKABLE_BEGIN,
-    WAR_UNBREAKABLE_END,
-} WarUnbreakableParam;
 
 typedef enum _WarUnitActionType
 {

--- a/src/war_fwd.h
+++ b/src/war_fwd.h
@@ -120,6 +120,9 @@ typedef struct _WarUnitCommandMapping WarUnitCommandMapping;
 struct _WarUnitCommandData;
 typedef struct _WarUnitCommandData WarUnitCommandData;
 
+struct _WarMapNode;
+typedef struct _WarMapNode WarMapNode;
+
 struct _WarMapPath;
 typedef struct _WarMapPath WarMapPath;
 

--- a/src/war_math.h
+++ b/src/war_math.h
@@ -2,6 +2,9 @@
 
 #include <stdbool.h>
 
+#include "shl/list.h"
+#include "shl/map.h"
+
 #include "common.h"
 
 #define SIGN(x) ((x) < 0 ? -1 : 1)

--- a/src/war_pathfinder.c
+++ b/src/war_pathfinder.c
@@ -1,52 +1,6 @@
-#include "war_pathfinder.h"
-
 #include <assert.h>
 
-typedef struct
-{
-    // id of the node
-    s32 id;
-
-    // the coordinates of the node
-    s32 x, y;
-
-    // the length of the path from the start to this node
-    s32 level;
-
-    // the previous node in the path from start to end passing through this node
-    s32 parent;
-
-    // the cost from the start to this node
-    s32 gScore;
-
-    // the cost from start to end passing through this node
-    s32 fScore;
-} WarMapNode;
-
-#define WarMapNodeEmpty (WarMapNode){0}
-
-static bool equalsMapNode(const WarMapNode node1, const WarMapNode node2)
-{
-    return node1.x == node2.x && node1.y == node2.y;
-}
-
-static s32 compareFScore(const WarMapNode node1, const WarMapNode node2)
-{
-    return node1.fScore - node2.fScore;
-}
-
-#ifdef __GNUC__
-// this is to silence GCC about this warning, I don't want to remove this function yet
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
-static s32 compareGScore(const WarMapNode node1, const WarMapNode node2)
-{
-    return node1.gScore - node2.gScore;
-}
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+#include "war_pathfinder.h"
 
 static s32 manhattanDistance(const WarMapNode node1, const WarMapNode node2)
 {
@@ -60,28 +14,29 @@ static s32 nodeDistanceSqr(const WarMapNode node1, const WarMapNode node2)
     return xx * xx + yy * yy;
 }
 
-static u32 hashMapNode(const s32 key)
+bool equalsMapNode(const WarMapNode node1, const WarMapNode node2)
+{
+    return node1.x == node2.x && node1.y == node2.y;
+}
+
+s32 compareFScore(const WarMapNode node1, const WarMapNode node2)
+{
+    return node1.fScore - node2.fScore;
+}
+
+u32 hashMapNode(const s32 key)
 {
     return (u32)key;
 }
 
-static bool equalsMapNodeId(const s32 key1, const s32 key2)
+bool equalsMapNodeId(const s32 key1, const s32 key2)
 {
     return key1 == key2;
 }
 
-shlDeclareList(WarMapNodeList, WarMapNode)
 shlDefineList(WarMapNodeList, WarMapNode)
-
-shlDeclareBinaryHeap(WarMapNodeHeap, WarMapNode)
 shlDefineBinaryHeap(WarMapNodeHeap, WarMapNode)
-
-shlDeclareMap(WarMapNodeMap, s32, WarMapNode)
 shlDefineMap(WarMapNodeMap, s32, WarMapNode)
-
-#define WarMapNodeListDefaultOptions (WarMapNodeListOptions){WarMapNodeEmpty, equalsMapNode}
-#define WarMapNodeHeapDefaultOptions (WarMapNodeHeapOptions){WarMapNodeEmpty, equalsMapNode, compareFScore}
-#define WarMapNodeMapDefaultOptions (WarMapNodeMapOptions){WarMapNodeEmpty, hashMapNode, equalsMapNodeId}
 
 static WarMapNode createNode(WarPathFinder finder, s32 x, s32 y)
 {

--- a/src/war_pathfinder.h
+++ b/src/war_pathfinder.h
@@ -1,6 +1,22 @@
 #pragma once
 
+#include "shl/binary_heap.h"
+#include "shl/list.h"
+#include "shl/map.h"
+
+#include "common.h"
+#include "war_fwd.h"
 #include "war_math.h"
+
+struct _WarMapNode
+{
+    s32 id;     // id of the node
+    s32 x, y;   // the coordinates of the node
+    s32 level;  // the length of the path from the start to this node
+    s32 parent; // the previous node in the path from start to end passing through this node
+    s32 gScore; // the cost from the start to this node
+    s32 fScore; // the cost from start to end passing through this node
+};
 
 struct _WarMapPath
 {
@@ -14,11 +30,27 @@ struct _WarPathFinder
     u16* data;
 };
 
-// this value is the distance squared to avoid dynamic units
+// NOTE: this value is the distance squared to avoid dynamic units
 // so if the dynamic entity at a distance squared less than this value,
 // treat it like a static one, so the unit can get around it and the risk of
 // overlapping units is less
 #define DISTANCE_SQR_AVOID_DYNAMIC_POSITIONS 2.0f
+
+#define WarMapNodeEmpty (WarMapNode){0}
+
+bool equalsMapNode(const WarMapNode node1, const WarMapNode node2);
+s32 compareFScore(const WarMapNode node1, const WarMapNode node2);
+
+u32 hashMapNode(const s32 key);
+bool equalsMapNodeId(const s32 key1, const s32 key2);
+
+shlDeclareList(WarMapNodeList, WarMapNode)
+shlDeclareBinaryHeap(WarMapNodeHeap, WarMapNode)
+shlDeclareMap(WarMapNodeMap, s32, WarMapNode)
+
+#define WarMapNodeListDefaultOptions (WarMapNodeListOptions){WarMapNodeEmpty, equalsMapNode}
+#define WarMapNodeHeapDefaultOptions (WarMapNodeHeapOptions){WarMapNodeEmpty, equalsMapNode, compareFScore}
+#define WarMapNodeMapDefaultOptions (WarMapNodeMapOptions){WarMapNodeEmpty, hashMapNode, equalsMapNodeId}
 
 u16 wpath_getTileValue(WarPathFinder finder, s32 x, s32 y);
 void wpath_setTilesValue(WarPathFinder finder, s32 startX, s32 startY, s32 width, s32 height, u16 value);

--- a/todo.md
+++ b/todo.md
@@ -170,10 +170,10 @@ This was the result of deleting the entity and the engine trying to free the spr
         * [x] Add unit cheat
     * [x] Make feedback for the cheats (the wascally wabbit notification?)
 * [x] Make sounds and music volume settings globally. That will allow to set volumes through cheats in any scene or map and mantain the setting through changing scenes.
+* [x] Make a profiler system.
+* [x] Remove global __log__ and move it to WarContext. How could I access the `__log__` inside `WarContext` in the `glfwErrorCallback` callback? C/ GLFW was changed by SLD3 and now log system uses SDL_log functions.
 * [ ] Write a detailed description of the actions system, maybe as comments in the `war_actions.c` file?
 * [ ] Manage components with a dictionary and not each entity having all the components.
-* [ ] Make a profiler system.
-* [ ] Remove global __log__ and move it to WarContext. How could I access the `__log__` inside `WarContext` in the `glfwErrorCallback` callback?
 * [ ] Make so that entities can have multiple sprites.
 * [ ] Add a `renderAnimations` function to render the animations above everything else and move the corresponding code in `renderUnit` to the new function.
 * [ ] Add animation for the gold and lumber numbers when they change.
@@ -307,7 +307,7 @@ This was the result of deleting the entity and the engine trying to free the spr
     * [x] Arrows
     * [x] Fireballs
     * [x] Rain of fire
-* [ ] Move actions system to animations, again? :| The problem is, for example in the move action, that the state machine does the moving, the wait between action steps are almost the same within the actions, and what is needed in reality is the changing frame, maybe the unbreakable markers and the sounds. I don't know maybe keep it, but removing the moving steps only.
+* [x] Move actions system to animations, again? :| The problem is, for example in the move action, that the state machine does the moving, the wait between action steps are almost the same within the actions, and what is needed in reality is the changing frame, maybe the unbreakable markers and the sounds. I don't know maybe keep it, but removing the moving steps only. C/ For now the actions system was simplified to remove the unbrakable and move steps, as they didn't represents anything meaninful in the code.
 
 ## State machine
 


### PR DESCRIPTION
This pull request refactors the unit action system to simplify how action steps are defined and processed. The main changes remove the concept of "unbreakable" action steps and the explicit "move" step from the action step sequence, streamlining both the data structures and the logic for updating actions. Additionally, the list utility usage is standardized across several files, and some code is reorganized for clarity and maintainability.

**Refactoring and Simplification of Action Steps:**

* Removed `WAR_ACTION_STEP_UNBREAKABLE` and all related logic and parameters from both the action step enum and the code that handled unbreakable sequences. This includes removing the `unbreakable` field from `WarUnitAction` and the associated logic in `wact_updateAction`. [[1]](diffhunk://#diff-e25d33d5f70484049b441eabc81d734a1fdd31d5456e4d75914fbfc5e6856263L600-L603) [[2]](diffhunk://#diff-e25d33d5f70484049b441eabc81d734a1fdd31d5456e4d75914fbfc5e6856263L614-L619) [[3]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL83-L84) [[4]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL124-L164) [[5]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL175-L184) [[6]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL197-L198) [[7]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL216-L217) [[8]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL230-L231) [[9]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL249-L250) [[10]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL263) [[11]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL283-L284) [[12]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL295-L296) [[13]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL306) [[14]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL316-L324) [[15]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL334-L342) [[16]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL361) [[17]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL373-L391) [[18]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL402-L412) [[19]](diffhunk://#diff-9aa5109209f906c6393c9ea222b2908820ebf9aefff3b8a61fe7b46c409d932fL35) [[20]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL1018) [[21]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL1148-L1157)
* Removed `WAR_ACTION_STEP_MOVE` from the action step enum and all related code, so movement is no longer an explicit step in these action definitions. [[1]](diffhunk://#diff-e25d33d5f70484049b441eabc81d734a1fdd31d5456e4d75914fbfc5e6856263L600-L603) [[2]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL124-L164) [[3]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL175-L184) [[4]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL373-L391) [[5]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL402-L412) [[6]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fL1186-L1198)

**Code Organization and Utility Improvements:**

* Moved the `equalsActionStep` function to a new implementation (`wact_equalsActionStep`) in `war_actions.c` and updated its usage throughout the codebase. Also standardized the use of the list utility macros for `WarUnitActionStepList`. [[1]](diffhunk://#diff-9aa5109209f906c6393c9ea222b2908820ebf9aefff3b8a61fe7b46c409d932fR3-R4) [[2]](diffhunk://#diff-9aa5109209f906c6393c9ea222b2908820ebf9aefff3b8a61fe7b46c409d932fL14-R20) [[3]](diffhunk://#diff-89a5c79819b5774ee025c755f61eabd916213fed8f460521d5240b84cee5405fR969-R975)
* Added missing includes for `shl/list.h` in several header files to ensure consistent list functionality. [[1]](diffhunk://#diff-9aa5109209f906c6393c9ea222b2908820ebf9aefff3b8a61fe7b46c409d932fR3-R4) [[2]](diffhunk://#diff-0be82013969d0c92be283f8cc2c81aa1b526e90e6d85c7ca014907ab8b693521R3) [[3]](diffhunk://#diff-e9ee05a1b2fe4ef39e77fffb281411f7350da603e3f8333a585627bb4d7c0c0cR3-R4) [[4]](diffhunk://#diff-2dbb9814e429bb32d737a0563090091f5a366101cfe42ac4c4e46c1cfcb6f2b2R4-R6)
* Minor forward declaration and organization improvements in `war_fwd.h` for clarity.

These changes make the action step system easier to maintain and extend by removing unnecessary complexity and improving codebase consistency.