### PR TITLE
Modernizes the input handling system & bug fixes

### DIFF
--- a/src/war.h
+++ b/src/war.h
@@ -114,21 +114,24 @@
 #define isRetail(context) ((context)->warFile->type == WAR_FILE_TYPE_RETAIL)
 #define isDemo(context) ((context)->warFile->type == WAR_FILE_TYPE_DEMO)
 
-#define isButtonPressed(input, btn) (input->buttons[btn].pressed)
-#define wasButtonPressed(input, btn) (input->buttons[btn].wasPressed)
-#define isKeyPressed(input, key) (input->keys[key].pressed)
-#define wasKeyPressed(input, key) (input->keys[key].wasPressed)
+#define isButtonHeld(input, btn) ((input)->buttons[btn].held)
+#define isButtonJustPressed(input, btn) ((input)->buttons[btn].justPressed)
+#define isButtonJustReleased(input, btn) ((input)->buttons[btn].justReleased)
+
+#define isKeyHeld(input, key) ((input)->keys[key].held)
+#define isKeyJustPressed(input, key) ((input)->keys[key].justPressed)
+#define isKeyJustReleased(input, key) ((input)->keys[key].justReleased)
+
+#define isMapDragging(input) ((input)->mapDragActive)
 
 #define getScaledSpeed(context, t) ((t) * (context)->globalSpeed)
 #define getScaledTime(context, t) ((t) / (context)->globalSpeed)
 
-struct _WarKeyButtonState
+struct _WarInputState
 {
-    // indicates if the key is pressed in the current frame
-    bool pressed;
-
-    // indicate if the key was pressed in the previous frame
-    bool wasPressed;
+    bool held;
+    bool justPressed;
+    bool justReleased;
 };
 
 struct _WarInput
@@ -137,16 +140,18 @@ struct _WarInput
     vec2 pos;
 
     // state of the mouse buttons
-    WarKeyButtonState buttons[WAR_MOUSE_COUNT];
+    WarInputState buttons[WAR_MOUSE_COUNT];
 
     // state of the keys
-    WarKeyButtonState keys[WAR_KEY_COUNT];
+    WarInputState keys[WAR_KEY_COUNT];
 
-    // drag
-    bool isDragging;
-    bool wasDragging;
-    vec2 dragPos;
-    rect dragRect;
+    // button currently owning the mouse press
+    WarEntityId capturedUIButtonId;
+
+    // map selection drag that started inside mapPanel
+    bool mapDragActive;
+    vec2 mapDragStartPos;
+    rect mapDragRect;
 };
 
 struct _WarRenderState

--- a/src/war_alloc.c
+++ b/src/war_alloc.c
@@ -1,4 +1,6 @@
 #include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #define SHL_MZ_IMPLEMENTATION
 #ifdef SHL_MZ_DEBUG
@@ -25,13 +27,46 @@ static void zoneReporter(const memzone_t* zone, mz_report_t report, const void* 
     logError("memzone: %s", message);
 }
 
-static bool is_in_zone(memzone_t* zone, void* p)
+static bool isInZone(memzone_t* zone, void* p)
 {
     if (!zone || !p) return false;
     uintptr_t ptr = (uintptr_t)p;
     uintptr_t z = (uintptr_t)zone;
     // maxSize is exactly the size of the whole allocated block
     return ptr >= z && ptr < (z + mz_maxSize(zone));
+}
+
+static void* allocInZone(memzone_t* zone, size_t sz, const char* file, int line)
+{
+#ifdef SHL_MZ_DEBUG
+    return mz__audit_alloc(zone, sz, file, line);
+#else
+    NOT_USED(file);
+    NOT_USED(line);
+    return mz_alloc(zone, sz);
+#endif
+}
+
+static void* reallocInZone(memzone_t* zone, void* p, size_t sz, const char* file, int line)
+{
+#ifdef SHL_MZ_DEBUG
+    return mz__audit_realloc(zone, p, sz, file, line);
+#else
+    NOT_USED(file);
+    NOT_USED(line);
+    return mz_realloc(zone, p, sz);
+#endif
+}
+
+static void freeInZone(memzone_t* zone, void* p, const char* file, int line)
+{
+#ifdef SHL_MZ_DEBUG
+    mz__audit_free(zone, p, file, line);
+#else
+    NOT_USED(file);
+    NOT_USED(line);
+    mz_free(zone, p);
+#endif
 }
 
 bool wm_allocInit(size_t permSize, size_t frameSize)
@@ -88,62 +123,65 @@ void wm_resetZone(void)
     currentZone = permanentZone;
 }
 
-void* wm_alloc(size_t sz)
+void* wm__alloc(size_t sz, const char* file, int line)
 {
-    return mz_alloc(currentZone, sz);
+    return allocInZone(currentZone, sz, file, line);
 }
 
-void* wm_allocFrame(size_t sz)
+void* wm__allocFrame(size_t sz, const char* file, int line)
 {
-    return mz_alloc(frameZone, sz);
+    return allocInZone(frameZone, sz, file, line);
 }
 
-void* wm_calloc(size_t n, size_t sz)
+void* wm__calloc(size_t n, size_t sz, const char* file, int line)
 {
     // Guard against n*sz wrapping to a smaller value on overflow.
-    if (n != 0 && sz > (size_t)-1 / n)
-        return NULL;
+    if (n != 0 && sz > (size_t)-1 / n) return NULL;
     // NOTE: mz_alloc already returns zeroed memory
-    return mz_alloc(currentZone, n * sz);
+    return allocInZone(currentZone, n * sz, file, line);
 }
 
-void* wm_realloc(void* p, size_t sz)
+void* wm__realloc(void* p, size_t sz, const char* file, int line)
 {
-    if (!p) return wm_alloc(sz);
+    if (!p) return wm__alloc(sz, file, line);
     if (sz == 0)
     {
-        wm_free(p);
+        wm__free(p, file, line);
         return NULL;
     }
 
-    if (is_in_zone(permanentZone, p))
+    if (isInZone(permanentZone, p))
     {
-        return mz_realloc(permanentZone, p, sz);
+        return reallocInZone(permanentZone, p, sz, file, line);
     }
 
-    if (is_in_zone(frameZone, p))
+    if (isInZone(frameZone, p))
     {
-        return mz_realloc(frameZone, p, sz);
+        return reallocInZone(frameZone, p, sz, file, line);
     }
 
     // fallback, if it's external or stdlib allocated
+    NOT_USED(file);
+    NOT_USED(line);
     return realloc(p, sz);
 }
 
-void wm_free(void* p)
+void wm__free(void* p, const char* file, int line)
 {
     if (!p) return;
 
-    if (is_in_zone(permanentZone, p))
+    if (isInZone(permanentZone, p))
     {
-        mz_free(permanentZone, p);
+        freeInZone(permanentZone, p, file, line);
     }
-    else if (is_in_zone(frameZone, p))
+    else if (isInZone(frameZone, p))
     {
-        mz_free(frameZone, p);
+        freeInZone(frameZone, p, file, line);
     }
     else
     {
+        NOT_USED(file);
+        NOT_USED(line);
         free(p); // fallback
     }
 }

--- a/src/war_alloc.h
+++ b/src/war_alloc.h
@@ -18,8 +18,15 @@ void wm_allocFree(void);
 void wm_setZone(memzone_t* zone);
 void wm_resetZone(void); // restores to permanentZone
 
-void* wm_alloc(size_t sz);
-void* wm_allocFrame(size_t sz);
-void* wm_calloc(size_t n, size_t sz);
-void* wm_realloc(void* p, size_t sz);
-void  wm_free(void* p);
+// Internal macro targets; prefer the wm_* macros below.
+void* wm__alloc(size_t sz, const char* file, int line);
+void* wm__allocFrame(size_t sz, const char* file, int line);
+void* wm__calloc(size_t n, size_t sz, const char* file, int line);
+void* wm__realloc(void* p, size_t sz, const char* file, int line);
+void  wm__free(void* p, const char* file, int line);
+
+#define wm_alloc(sz)          wm__alloc((sz), __FILE__, __LINE__)
+#define wm_allocFrame(sz)     wm__allocFrame((sz), __FILE__, __LINE__)
+#define wm_calloc(n, sz)      wm__calloc((n), (sz), __FILE__, __LINE__)
+#define wm_realloc(p, sz)     wm__realloc((p), (sz), __FILE__, __LINE__)
+#define wm_free(p)            wm__free((p), __FILE__, __LINE__)

--- a/src/war_cheats_panel.c
+++ b/src/war_cheats_panel.c
@@ -138,10 +138,10 @@ void wcheatp_updateCheatsPanel(WarContext* context)
 
     if (cheatStatus->visible)
     {
-        if (wasKeyPressed(input, WAR_KEY_ESC) ||
-            wasKeyPressed(input, WAR_KEY_ENTER))
+        if (isKeyJustReleased(input, WAR_KEY_ESC) ||
+            isKeyJustReleased(input, WAR_KEY_ENTER))
         {
-            if (wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ENTER))
             {
                 wcheat_applyCheat(context, wstr_view(&cheatStatus->text));
             }
@@ -150,7 +150,7 @@ void wcheatp_updateCheatsPanel(WarContext* context)
             return;
         }
 
-        if (wasKeyPressed(input, WAR_KEY_TAB))
+        if (isKeyJustReleased(input, WAR_KEY_TAB))
         {
             s32 length = (s32)cheatStatus->text.length;
             if (TAB_WIDTH <= STATUS_TEXT_MAX_LENGTH - length)
@@ -159,7 +159,7 @@ void wcheatp_updateCheatsPanel(WarContext* context)
                 cheatStatus->position++;
             }
         }
-        else if (wasKeyPressed(input, WAR_KEY_BACKSPACE))
+        else if (isKeyJustReleased(input, WAR_KEY_BACKSPACE))
         {
             if (cheatStatus->position > 0)
             {
@@ -167,7 +167,7 @@ void wcheatp_updateCheatsPanel(WarContext* context)
                 cheatStatus->position--;
             }
         }
-        else if (wasKeyPressed(input, WAR_KEY_DELETE))
+        else if (isKeyJustReleased(input, WAR_KEY_DELETE))
         {
             s32 length = (s32)cheatStatus->text.length;
             if (cheatStatus->position < length)
@@ -175,7 +175,7 @@ void wcheatp_updateCheatsPanel(WarContext* context)
                 wstr_removeRange(&cheatStatus->text, cheatStatus->position, 1);
             }
         }
-        else if (wasKeyPressed(input, WAR_KEY_RIGHT))
+        else if (isKeyJustReleased(input, WAR_KEY_RIGHT))
         {
             s32 length = (s32)cheatStatus->text.length;
             if (cheatStatus->position < length)
@@ -183,18 +183,18 @@ void wcheatp_updateCheatsPanel(WarContext* context)
                 cheatStatus->position++;
             }
         }
-        else if (wasKeyPressed(input, WAR_KEY_LEFT))
+        else if (isKeyJustReleased(input, WAR_KEY_LEFT))
         {
             if (cheatStatus->position > 0)
             {
                 cheatStatus->position--;
             }
         }
-        else if (wasKeyPressed(input, WAR_KEY_HOME))
+        else if (isKeyJustReleased(input, WAR_KEY_HOME))
         {
             cheatStatus->position = 0;
         }
-        else if (wasKeyPressed(input, WAR_KEY_END))
+        else if (isKeyJustReleased(input, WAR_KEY_END))
         {
             s32 length = (s32)cheatStatus->text.length;
             cheatStatus->position = length;
@@ -224,7 +224,7 @@ void wcheatp_updateCheatsPanel(WarContext* context)
         setUIEntityStatus(cheatCursor, false);
         setUIEntityStatus(cheatText, false);
 
-        if (wasKeyPressed(input, WAR_KEY_ENTER))
+        if (isKeyJustReleased(input, WAR_KEY_ENTER))
         {
             wcheatp_setCheatsPanelVisible(context, true);
         }

--- a/src/war_commands.c
+++ b/src/war_commands.c
@@ -82,7 +82,7 @@ void wcmd_executeMoveCommand(WarContext* context, vec2 targetPoint)
 
         if (wu_isDudeUnit(entity) && wu_isFriendlyUnit(context, entity))
         {
-            if (isKeyPressed(input, WAR_KEY_SHIFT))
+            if (isKeyHeld(input, WAR_KEY_SHIFT))
             {
                 if (isPatrolling(entity))
                 {
@@ -590,7 +590,7 @@ bool wcmd_executeCommand(WarContext* context)
     {
         case WAR_COMMAND_MOVE:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -625,7 +625,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_HARVEST:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -683,7 +683,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_REPAIR:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -710,7 +710,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_ATTACK:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -850,7 +850,7 @@ bool wcmd_executeCommand(WarContext* context)
         case WAR_COMMAND_BUILD_BLACKSMITH_HUMANS:
         case WAR_COMMAND_BUILD_BLACKSMITH_ORCS:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -891,7 +891,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_BUILD_WALL:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -939,7 +939,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_BUILD_ROAD:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -996,7 +996,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_SPELL_RAIN_OF_FIRE:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -1023,7 +1023,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_SPELL_POISON_CLOUD:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -1050,7 +1050,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_SPELL_HEALING:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -1072,7 +1072,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_SPELL_INVISIBILITY:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -1094,7 +1094,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_SPELL_UNHOLY_ARMOR:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -1116,7 +1116,7 @@ bool wcmd_executeCommand(WarContext* context)
 
         case WAR_COMMAND_SPELL_RAISE_DEAD:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {
@@ -1136,7 +1136,7 @@ bool wcmd_executeCommand(WarContext* context)
         case WAR_COMMAND_SPELL_FAR_SIGHT:
         case WAR_COMMAND_SPELL_DARK_VISION:
         {
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
             {
                 if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
                 {

--- a/src/war_fwd.h
+++ b/src/war_fwd.h
@@ -3,11 +3,11 @@
 #include <stdint.h>
 #include "war_enums.h"
 
-struct _WarKeyButtonState;
-typedef struct _WarKeyButtonState WarKeyButtonState;
-
 struct _WarInput;
 typedef struct _WarInput WarInput;
+
+struct _WarInputState;
+typedef struct _WarInputState WarInputState;
 
 struct _WarFontData;
 typedef struct _WarFontData WarFontData;

--- a/src/war_game.c
+++ b/src/war_game.c
@@ -387,17 +387,35 @@ void wg_setNextMap(WarContext* context, WarMap* map, f32 transitionDelay)
 void wg_setInputButton(WarContext* context, s32 button, bool pressed)
 {
     WarInput* input = &context->input;
+    WarInputState* state = &input->buttons[button];
 
-    input->buttons[button].wasPressed = input->buttons[button].pressed && !pressed;
-    input->buttons[button].pressed = pressed;
+    if (pressed && !state->held)
+    {
+        state->justPressed = true;
+    }
+    else if (!pressed && state->held)
+    {
+        state->justReleased = true;
+    }
+
+    state->held = pressed;
 }
 
 void wg_setInputKey(WarContext* context, s32 key, bool pressed)
 {
     WarInput* input = &context->input;
+    WarInputState* state = &input->keys[key];
 
-    input->keys[key].wasPressed = input->keys[key].pressed && !pressed;
-    input->keys[key].pressed = pressed;
+    if (pressed && !state->held)
+    {
+        state->justPressed = true;
+    }
+    else if (!pressed && state->held)
+    {
+        state->justReleased = true;
+    }
+
+    state->held = pressed;
 }
 
 void wg_beginInputFrame(WarContext* context)
@@ -406,19 +424,21 @@ void wg_beginInputFrame(WarContext* context)
 
     for (s32 i = 0; i < WAR_MOUSE_COUNT; ++i)
     {
-        input->buttons[i].wasPressed = false;
+        input->buttons[i].justPressed = false;
+        input->buttons[i].justReleased = false;
     }
 
     for (s32 i = 0; i < WAR_KEY_COUNT; ++i)
     {
-        input->keys[i].wasPressed = false;
+        input->keys[i].justPressed = false;
+        input->keys[i].justReleased = false;
     }
-
-    input->wasDragging = false;
 }
 
 void wg_processGameEvent(WarContext* context, SDL_Event* event)
 {
+    WarInput* input = &context->input;
+
     // NOTE: Convert event coordinates from window space to logical render space (320x200).
     // SDL_SetRenderLogicalPresentation does NOT do this automatically in SDL3.
     SDL_ConvertEventToRenderCoordinates(context->renderer, event);
@@ -427,25 +447,22 @@ void wg_processGameEvent(WarContext* context, SDL_Event* event)
     {
         case SDL_EVENT_MOUSE_MOTION:
         {
-            vec2 pos = vec2f((f32)floorf(event->motion.x), (f32)floorf(event->motion.y));
-            context->input.pos = pos;
+            input->pos = vec2f((f32)floorf(event->motion.x), (f32)floorf(event->motion.y));
             break;
         }
 
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
         case SDL_EVENT_MOUSE_BUTTON_UP:
         {
-            vec2 pos = vec2f((f32)floorf(event->button.x), (f32)floorf(event->button.y));
-            context->input.pos = pos;
+            input->pos = vec2f((f32)floorf(event->button.x), (f32)floorf(event->button.y));
 
-            bool pressed = event->button.down;
             if (event->button.button == SDL_BUTTON_LEFT)
             {
-                wg_setInputButton(context, WAR_MOUSE_LEFT, pressed);
+                wg_setInputButton(context, WAR_MOUSE_LEFT, event->button.down);
             }
             else if (event->button.button == SDL_BUTTON_RIGHT)
             {
-                wg_setInputButton(context, WAR_MOUSE_RIGHT, pressed);
+                wg_setInputButton(context, WAR_MOUSE_RIGHT, event->button.down);
             }
             break;
         }
@@ -482,28 +499,40 @@ void wg_processGameEvent(WarContext* context, SDL_Event* event)
             wg_appendCheatTextInput(context, wsv_fromCString(event->text.text));
             break;
 
+        case SDL_EVENT_WINDOW_FOCUS_GAINED:
+            if (!SDL_SetWindowMouseGrab(context->window, true))
+            {
+                logError("Error setting window mouse grab: %s", SDL_GetError());
+            }
+            break;
+
         case SDL_EVENT_WINDOW_FOCUS_LOST:
         case SDL_EVENT_WINDOW_MINIMIZED:
         case SDL_EVENT_WINDOW_HIDDEN:
         {
-            WarInput* input = &context->input;
-
             for (s32 i = 0; i < WAR_MOUSE_COUNT; ++i)
             {
-                input->buttons[i].pressed = false;
-                input->buttons[i].wasPressed = false;
+                input->buttons[i].held = false;
+                input->buttons[i].justPressed = false;
+                input->buttons[i].justReleased = false;
             }
 
             for (s32 i = 0; i < WAR_KEY_COUNT; ++i)
             {
-                input->keys[i].pressed = false;
-                input->keys[i].wasPressed = false;
+                input->keys[i].held = false;
+                input->keys[i].justPressed = false;
+                input->keys[i].justReleased = false;
             }
 
-            input->isDragging = false;
-            input->wasDragging = false;
-            input->dragPos = VEC2_ZERO;
-            input->dragRect = RECT_EMPTY;
+            input->capturedUIButtonId = 0;
+            input->mapDragActive = false;
+            input->mapDragStartPos = VEC2_ZERO;
+            input->mapDragRect = RECT_EMPTY;
+
+            if (!SDL_SetWindowMouseGrab(context->window, false))
+            {
+                logError("Error setting window mouse grab: %s", SDL_GetError());
+            }
             break;
         }
 
@@ -537,8 +566,8 @@ void wg_updateGame(WarContext* context)
 
     WarInput* input = &context->input;
 
-    if (isKeyPressed(input, WAR_KEY_CTRL) &&
-        wasKeyPressed(input, WAR_KEY_P))
+    if (isKeyHeld(input, WAR_KEY_CTRL) &&
+        isKeyJustReleased(input, WAR_KEY_P))
     {
         context->paused = !context->paused;
     }

--- a/src/war_map.c
+++ b/src/war_map.c
@@ -21,6 +21,8 @@
 #include "war_units.h"
 #include "war_pathfinder.h"
 
+#define MAP_SELECTION_DRAG_THRESHOLD 3.0f
+
 void wmap_addEntityToSelection(WarContext* context, WarEntityId id)
 {
     WarMap* map = context->map;
@@ -48,14 +50,14 @@ vec2 wmap_getDirFromArrowKeys(WarContext* context)
 
     vec2 dir = VEC2_ZERO;
 
-    if (isKeyPressed(input, WAR_KEY_LEFT))
+    if (isKeyHeld(input, WAR_KEY_LEFT))
         dir.x = -1;
-    else if (isKeyPressed(input, WAR_KEY_RIGHT))
+    else if (isKeyHeld(input, WAR_KEY_RIGHT))
         dir.x = 1;
 
-    if (isKeyPressed(input, WAR_KEY_DOWN))
+    if (isKeyHeld(input, WAR_KEY_DOWN))
         dir.y = 1;
-    else if (isKeyPressed(input, WAR_KEY_UP))
+    else if (isKeyHeld(input, WAR_KEY_UP))
         dir.y = -1;
 
     dir = vec2_normalize(dir);
@@ -860,7 +862,7 @@ void wmap_leaveMap(WarContext* context)
     }
 }
 
-void updateViewport(WarContext *context)
+static void updateViewport(WarContext *context)
 {
     WarMap* map = context->map;
     WarInput* input = &context->input;
@@ -873,7 +875,7 @@ void updateViewport(WarContext *context)
     bool keyScroll = false;
 
     // if there was a click in the minimap, then update the position of the viewport
-    if (isButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonHeld(input, WAR_MOUSE_LEFT))
     {
         // check if the click is inside the minimap panel
         if (rect_containsf(map->minimapPanel, input->pos.x, input->pos.y))
@@ -885,20 +887,20 @@ void updateViewport(WarContext *context)
             map->viewport.x = offset.x * MAP_WIDTH / minimapSize.x;
             map->viewport.y = offset.y * MAP_HEIGHT / minimapSize.y;
         }
-        // check if it was at the edge of the map to scroll also and update the position of the viewport
-        else if(!input->isDragging)
-        {
-            dir = wmap_getDirFromMousePos(context);
-            mouseScroll = true;
-        }
     }
     // check for the arrows keys and update the position of the viewport
     else
     {
+        if (!isMapDragging(input))
+        {
+            dir = wmap_getDirFromMousePos(context);
+            mouseScroll = !VEC2_IS_ZERO(dir);
+        }
+
         // don't scroll with arrow keys if Control or Shift are pressed
         // don't scroll with arrow keys if the cheat status is active
-        if (!isKeyPressed(input, WAR_KEY_CTRL) &&
-            !isKeyPressed(input, WAR_KEY_SHIFT) &&
+        if (!isKeyHeld(input, WAR_KEY_CTRL) &&
+            !isKeyHeld(input, WAR_KEY_SHIFT) &&
             !cheatsEnabledAndVisible(map))
         {
             dir = wmap_getDirFromArrowKeys(context);
@@ -934,35 +936,116 @@ void updateDragRect(WarContext* context)
     WarMap* map = context->map;
     WarInput* input = &context->input;
 
-    input->wasDragging = false;
-    input->dragRect = RECT_EMPTY;
-
     if (map->isScrolling)
     {
-        input->isDragging = false;
-        input->dragPos = VEC2_ZERO;
+        input->mapDragActive = false;
+        input->mapDragStartPos = VEC2_ZERO;
+        input->mapDragRect = RECT_EMPTY;
         return;
     }
 
-    if (isButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
-        if(rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
+        if (!input->capturedUIButtonId && rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
-            if (!input->isDragging)
+            input->mapDragActive = true;
+            input->mapDragStartPos = input->pos;
+            input->mapDragRect = rectv(input->pos, VEC2_ZERO);
+        }
+    }
+    else if (input->mapDragActive && isButtonHeld(input, WAR_MOUSE_LEFT))
+    {
+        input->mapDragRect = rectpf(input->mapDragStartPos.x, input->mapDragStartPos.y, input->pos.x, input->pos.y);
+    }
+}
+
+static bool isMapSelectionDrag(rect dragRect)
+{
+    return dragRect.width >= MAP_SELECTION_DRAG_THRESHOLD ||
+           dragRect.height >= MAP_SELECTION_DRAG_THRESHOLD;
+}
+
+static void updateSelectionFromList(WarContext* context, WarEntityList* newSelectedEntities)
+{
+    WarMap* map = context->map;
+
+    bool areDudesSelected = false;
+    bool areBuildingSelected = false;
+
+    // calculate the number of dudes and buildings in the selection
+    for (s32 i = 0; i < newSelectedEntities->count; i++)
+    {
+        WarEntity* entity = newSelectedEntities->items[i];
+        if (wu_isDudeUnit(entity))
+            areDudesSelected = true;
+        else if (wu_isBuildingUnit(entity))
+            areBuildingSelected = true;
+    }
+
+    if (areDudesSelected)
+    {
+        // remove all new selected buildings
+        for (s32 i = newSelectedEntities->count - 1; i >= 0; i--)
+        {
+            WarEntity* entity = newSelectedEntities->items[i];
+            if (wu_isBuildingUnit(entity))
+                WarEntityListRemoveAt(newSelectedEntities, i);
+        }
+    }
+    else if (areBuildingSelected)
+    {
+        // remove all other new selected buildings
+        WarEntityListRemoveAtRange(newSelectedEntities, 1, newSelectedEntities->count - 1);
+    }
+
+    if (areDudesSelected)
+    {
+        if (newSelectedEntities->count == 1)
+        {
+            WarEntity* newSelectedEntity = newSelectedEntities->items[0];
+            if (wu_isFriendlyUnit(context, newSelectedEntity))
             {
-                input->dragPos = input->pos;
-                input->isDragging = true;
+                wa_playDudeSelectionSound(context, newSelectedEntity);
+            }
+            else
+            {
+                wa_createAudio(context, WAR_UI_CLICK, false);
             }
         }
     }
-    else if(wasButtonPressed(input, WAR_MOUSE_LEFT))
+    else if (areBuildingSelected)
     {
-        if (input->isDragging)
+        WarEntity* newSelectedEntity = newSelectedEntities->items[0];
+        if (wu_isFriendlyUnit(context, newSelectedEntity))
         {
-            input->isDragging = false;
-            input->wasDragging = true;
-            input->dragRect = rectpf(input->dragPos.x, input->dragPos.y, input->pos.x, input->pos.y);
+            wa_playBuildingSelectionSound(context, newSelectedEntity);
         }
+    }
+
+    // if the new selected entity is the same one, don't clear the command, otherwise do
+    if (newSelectedEntities->count == 1 && map->selectedEntities.count == 1)
+    {
+        WarEntity* newSelectedEntity = newSelectedEntities->items[0];
+        WarEntityId selectedEntityId = map->selectedEntities.items[0];
+        if (selectedEntityId != newSelectedEntity->id)
+        {
+            map->command.type = WAR_COMMAND_NONE;
+        }
+    }
+    else
+    {
+        map->command.type = WAR_COMMAND_NONE;
+    }
+
+    // clear the current selection
+    wmap_clearSelection(context);
+
+    // and add the new selection
+    s32 selectedEntitiesCount = MIN(newSelectedEntities->count, 4);
+    for (s32 i = 0; i < selectedEntitiesCount; i++)
+    {
+        WarEntity* entity = newSelectedEntities->items[i];
+        wmap_addEntityToSelection(context, entity->id);
     }
 }
 
@@ -971,22 +1054,23 @@ void updateSelection(WarContext* context)
     WarMap* map = context->map;
     WarInput* input = &context->input;
 
-    if(wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustReleased(input, WAR_MOUSE_LEFT) && input->mapDragActive)
     {
         // if it was scrolling last frame, don't perform any selection this frame
         if (!map->wasScrolling)
         {
-            // check if the click is inside the map panel
-            if(input->wasDragging || rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
-            {
-                WarEntityList newSelectedEntities;
-                WarEntityListInit(&newSelectedEntities, WarEntityListNonFreeOptions);
+            input->mapDragRect = rectpf(input->mapDragStartPos.x, input->mapDragStartPos.y, input->pos.x, input->pos.y);
 
-                rect pointerRect = wmap_screenToMapCoordinatesR(context, input->dragRect);
+            WarEntityList newSelectedEntities;
+            WarEntityListInit(&newSelectedEntities, WarEntityListNonFreeOptions);
+
+            if (isMapSelectionDrag(input->mapDragRect))
+            {
+                rect pointerRect = wmap_screenToMapCoordinatesR(context, input->mapDragRect);
 
                 // select the entities inside the dragging rect
                 WarEntityList* units = we_getEntitiesOfType(context, WAR_ENTITY_TYPE_UNIT);
-                for(s32 i = 0; i < units->count; i++)
+                for (s32 i = 0; i < units->count; i++)
                 {
                     WarEntity* entity = units->items[i];
                     if (entity)
@@ -1026,103 +1110,48 @@ void updateSelection(WarContext* context)
                         }
                     }
                 }
-
-                // include the already selected entities if the Ctrl key is pressed
-                if (isKeyPressed(input, WAR_KEY_CTRL))
-                {
-                    // the max number of selected entities is 4, so there is no much
-                    // throuble looking for the actual entities here, it will also
-                    // improve when a hash is make for looking up the entities
-                    for (s32 i = 0; i < map->selectedEntities.count; i++)
-                    {
-                        WarEntity* entity = we_findEntity(context, map->selectedEntities.items[i]);
-                        if (entity)
-                            WarEntityListAdd(&newSelectedEntities, entity);
-                    }
-                }
-
-                bool areDudesSelected = false;
-                bool areBuildingSelected = false;
-
-                // calculate the number of dudes and buildings in the selection
-                for (s32 i = 0; i < newSelectedEntities.count; i++)
-                {
-                    WarEntity* entity = newSelectedEntities.items[i];
-                    if (wu_isDudeUnit(entity))
-                        areDudesSelected = true;
-                    else if (wu_isBuildingUnit(entity))
-                        areBuildingSelected = true;
-                }
-
-                if (areDudesSelected)
-                {
-                    // remove all new selected buildings
-                    for (s32 i = newSelectedEntities.count - 1; i >= 0; i--)
-                    {
-                        WarEntity* entity = newSelectedEntities.items[i];
-                        if (wu_isBuildingUnit(entity))
-                            WarEntityListRemoveAt(&newSelectedEntities, i);
-                    }
-                }
-                else if (areBuildingSelected)
-                {
-                    // remove all other new selected buildings
-                    WarEntityListRemoveAtRange(&newSelectedEntities, 1, newSelectedEntities.count - 1);
-                }
-
-                if (areDudesSelected)
-                {
-                    if (newSelectedEntities.count == 1)
-                    {
-                        WarEntity* newSelectedEntity = newSelectedEntities.items[0];
-                        if (wu_isFriendlyUnit(context, newSelectedEntity))
-                        {
-                            wa_playDudeSelectionSound(context, newSelectedEntity);
-                        }
-                        else
-                        {
-                            wa_createAudio(context, WAR_UI_CLICK, false);
-                        }
-                    }
-                }
-                else if (areBuildingSelected)
-                {
-                    WarEntity* newSelectedEntity = newSelectedEntities.items[0];
-                    if (wu_isFriendlyUnit(context, newSelectedEntity))
-                    {
-                        wa_playBuildingSelectionSound(context, newSelectedEntity);
-                    }
-                }
-
-                // if the new selected entity is the same one, don't clear the command, otherwise do
-                if (newSelectedEntities.count == 1 && map->selectedEntities.count == 1)
-                {
-                    WarEntity* newSelectedEntity = newSelectedEntities.items[0];
-                    WarEntityId selectedEntityId = map->selectedEntities.items[0];
-                    if (selectedEntityId != newSelectedEntity->id)
-                    {
-                        map->command.type = WAR_COMMAND_NONE;
-                    }
-                }
-                else
-                {
-                    map->command.type = WAR_COMMAND_NONE;
-                }
-
-                // clear the current selection
-                wmap_clearSelection(context);
-
-                // and add the new selection
-                s32 selectedEntitiesCount = MIN(newSelectedEntities.count, 4);
-                for (s32 i = 0; i < selectedEntitiesCount; i++)
-                {
-                    WarEntity* entity = newSelectedEntities.items[i];
-                    wmap_addEntityToSelection(context, entity->id);
-                }
-
-                WarEntityListFree(&newSelectedEntities);
             }
+            else
+            {
+                WarEntity* entityUnderCursor = we_findEntityUnderCursor(context, false, false);
+                if (entityUnderCursor)
+                {
+                    WarUnitComponent* unit = &entityUnderCursor->unit;
+                    if (unit->enabled &&
+                        !isDead(entityUnderCursor) &&
+                        !isGoingToDie(entityUnderCursor) &&
+                        !wu_isCorpseUnit(entityUnderCursor) &&
+                        !isCollapsing(entityUnderCursor) &&
+                        !isGoingToCollapse(entityUnderCursor) &&
+                        !(wu_isWorkerUnit(entityUnderCursor) && wst_isInsideBuilding(entityUnderCursor)) &&
+                        isUnitPartiallyVisible(map, entityUnderCursor))
+                    {
+                        WarEntityListAdd(&newSelectedEntities, entityUnderCursor);
+                    }
+                }
+            }
+
+            // include the already selected entities if the Ctrl key is pressed
+            if (isKeyHeld(input, WAR_KEY_CTRL))
+            {
+                // the max number of selected entities is 4, so there is no much
+                // throuble looking for the actual entities here, it will also
+                // improve when a hash is make for looking up the entities
+                for (s32 i = 0; i < map->selectedEntities.count; i++)
+                {
+                    WarEntity* entity = we_findEntity(context, map->selectedEntities.items[i]);
+                    if (entity)
+                        WarEntityListAdd(&newSelectedEntities, entity);
+                }
+            }
+
+            updateSelectionFromList(context, &newSelectedEntities);
+            WarEntityListFree(&newSelectedEntities);
         }
+
+        input->mapDragActive = false;
+        input->mapDragStartPos = VEC2_ZERO;
+        input->mapDragRect = RECT_EMPTY;
     }
 }
 
@@ -1134,7 +1163,7 @@ void updateTreesEdit(WarContext* context)
     if (!map->editingTrees)
         return;
 
-    if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
         if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
@@ -1174,7 +1203,7 @@ void updateRoadsEdit(WarContext* context)
     if (!map->editingRoads)
         return;
 
-    if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
         if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
@@ -1209,7 +1238,7 @@ void updateWallsEdit(WarContext* context)
     if (!map->editingWalls)
         return;
 
-    if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
         if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
@@ -1249,7 +1278,7 @@ void updateRuinsEdit(WarContext* context)
     if (!map->editingRuins)
         return;
 
-    if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
         if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
@@ -1284,7 +1313,7 @@ void updateRainOfFireEdit(WarContext* context)
     if (!map->editingRainOfFire)
         return;
 
-    if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
         if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
@@ -1307,7 +1336,7 @@ void updateAddUnit(WarContext* context)
     if (!map->addingUnit)
         return;
 
-    if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT))
     {
         if (rect_containsf(map->mapPanel, input->pos.x, input->pos.y))
         {
@@ -1452,7 +1481,7 @@ void updateCommandFromRightClick(WarContext* context)
     WarUnitCommand* command = &map->command;
     WarInput* input = &context->input;
 
-    if (wasButtonPressed(input, WAR_MOUSE_RIGHT))
+    if (isButtonJustPressed(input, WAR_MOUSE_RIGHT))
     {
         if (command->type == WAR_COMMAND_NONE)
         {
@@ -1592,10 +1621,10 @@ void updateStatus(WarContext* context)
 
         if (cheatStatus->visible)
         {
-            if (wasKeyPressed(input, WAR_KEY_ESC) ||
-                wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ESC) ||
+                isKeyJustReleased(input, WAR_KEY_ENTER))
             {
-                if (wasKeyPressed(input, WAR_KEY_ENTER))
+                if (isKeyJustReleased(input, WAR_KEY_ENTER))
                 {
                     wcheat_applyCheat(context, wsv_fromString(&cheatStatus->text));
                 }
@@ -1604,7 +1633,7 @@ void updateStatus(WarContext* context)
                 return;
             }
 
-            if (wasKeyPressed(input, WAR_KEY_TAB))
+            if (isKeyJustReleased(input, WAR_KEY_TAB))
             {
                 s32 length = (s32)cheatStatus->text.length;
                 if (TAB_WIDTH <= STATUS_TEXT_MAX_LENGTH - length)
@@ -1613,7 +1642,7 @@ void updateStatus(WarContext* context)
                     cheatStatus->position++;
                 }
             }
-            else if (wasKeyPressed(input, WAR_KEY_BACKSPACE))
+            else if (isKeyJustReleased(input, WAR_KEY_BACKSPACE))
             {
                 if (cheatStatus->position > 0)
                 {
@@ -1621,7 +1650,7 @@ void updateStatus(WarContext* context)
                     cheatStatus->position--;
                 }
             }
-            else if (wasKeyPressed(input, WAR_KEY_DELETE))
+            else if (isKeyJustReleased(input, WAR_KEY_DELETE))
             {
                 s32 length = (s32)cheatStatus->text.length;
                 if (cheatStatus->position < length)
@@ -1629,7 +1658,7 @@ void updateStatus(WarContext* context)
                     wstr_removeRange(&cheatStatus->text, cheatStatus->position, 1);
                 }
             }
-            else if (wasKeyPressed(input, WAR_KEY_RIGHT))
+            else if (isKeyJustReleased(input, WAR_KEY_RIGHT))
             {
                 s32 length = (s32)cheatStatus->text.length;
                 if (cheatStatus->position < length)
@@ -1637,18 +1666,18 @@ void updateStatus(WarContext* context)
                     cheatStatus->position++;
                 }
             }
-            else if (wasKeyPressed(input, WAR_KEY_LEFT))
+            else if (isKeyJustReleased(input, WAR_KEY_LEFT))
             {
                 if (cheatStatus->position > 0)
                 {
                     cheatStatus->position--;
                 }
             }
-            else if (wasKeyPressed(input, WAR_KEY_HOME))
+            else if (isKeyJustReleased(input, WAR_KEY_HOME))
             {
                 cheatStatus->position = 0;
             }
-            else if (wasKeyPressed(input, WAR_KEY_END))
+            else if (isKeyJustReleased(input, WAR_KEY_END))
             {
                 s32 length = (s32)cheatStatus->text.length;
                 cheatStatus->position = length;
@@ -1675,7 +1704,7 @@ void updateStatus(WarContext* context)
         {
             setUIEntityStatus(statusCursor, false);
 
-            if (wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ENTER))
             {
                 wcheatp_setCheatsPanelVisible(context, true);
             }
@@ -1804,7 +1833,7 @@ void updateMapCursor(WarContext* context)
             return;
         }
 
-        if (input->isDragging)
+        if (isMapDragging(input))
         {
             wui_changeCursorType(context, entity, WAR_CURSOR_GREEN_CROSSHAIR);
             return;
@@ -2496,15 +2525,20 @@ void wmap_updateMap(WarContext* context)
 {
     WarMap* map = context->map;
 
-    updateViewport(context);
-    updateDragRect(context);
-
     if (!map->playing)
     {
+        WarInput* input = &context->input;
+        input->mapDragActive = false;
+        input->mapDragStartPos = VEC2_ZERO;
+        input->mapDragRect = RECT_EMPTY;
+
         wui_updateUIButtons(context, true);
         updateMapCursor(context);
         return;
     }
+
+    updateViewport(context);
+    updateDragRect(context);
 
     if (!wcmd_executeCommand(context))
     {

--- a/src/war_map_ui.c
+++ b/src/war_map_ui.c
@@ -378,9 +378,9 @@ void wmui_renderSelectionRect(WarContext* context)
     wr_save(context);
 
     WarInput* input = &context->input;
-    if (input->isDragging)
+    if (isMapDragging(input))
     {
-        rect pointerRect = rectpf(input->dragPos.x, input->dragPos.y, input->pos.x, input->pos.y);
+        rect pointerRect = rectpf(input->mapDragStartPos.x, input->mapDragStartPos.y, input->pos.x, input->pos.y);
         wr_strokeRect(context, pointerRect, WAR_COLOR_GREEN_SELECTION, 1.0f);
     }
 

--- a/src/war_scene_briefing.c
+++ b/src/war_scene_briefing.c
@@ -151,9 +151,9 @@ void wsc_updateSceneBriefing(WarContext* context)
     wanim_updateAnimations(context);
 
     if (scene->briefing.time <= 0 ||
-        wasButtonPressed(input, WAR_MOUSE_LEFT) ||
-        wasKeyPressed(input, WAR_KEY_ENTER) ||
-        wasKeyPressed(input, WAR_KEY_SPACE))
+        isButtonJustPressed(input, WAR_MOUSE_LEFT) ||
+        isKeyJustPressed(input, WAR_KEY_ENTER) ||
+        isKeyJustPressed(input, WAR_KEY_SPACE))
     {
         WarMap* map = wmap_createMap(context, scene->briefing.mapType);
         wg_setNextMap(context, map, 1.0f);

--- a/src/war_scene_download.c
+++ b/src/war_scene_download.c
@@ -54,7 +54,7 @@ void wsc_updateSceneDownload(WarContext* context)
     {
         case WAR_SCENE_DOWNLOAD_DOWNLOAD:
         {
-            if (wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ENTER))
             {
                 static const char confirm[] = "The DEMO DATA.WAR doesn't have all assets.\n"
                                               "\n"
@@ -76,7 +76,7 @@ void wsc_updateSceneDownload(WarContext* context)
         }
         case WAR_SCENE_DOWNLOAD_CONFIRM:
         {
-            if (wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ENTER))
             {
                 WarEntity* downloadingText = we_findUIEntity(context, wsv_fromCString("txtDownloading"));
                 setUIEntityStatus(downloadingText, true);
@@ -108,7 +108,7 @@ void wsc_updateSceneDownload(WarContext* context)
         }
         case WAR_SCENE_DOWNLOAD_DOWNLOADED:
         {
-            if (wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ENTER))
             {
                 // load DATA.WAR file
                 if (wg_loadDataFile(context))
@@ -132,7 +132,7 @@ void wsc_updateSceneDownload(WarContext* context)
         }
         case WAR_SCENE_DOWNLOAD_FAILED:
         {
-            if (wasKeyPressed(input, WAR_KEY_ENTER))
+            if (isKeyJustReleased(input, WAR_KEY_ENTER))
             {
                 SDL_PushEvent(&(SDL_Event){ .type = SDL_EVENT_QUIT });
             }

--- a/src/war_ui.c
+++ b/src/war_ui.c
@@ -228,14 +228,15 @@ void wui_updateUICursor(WarContext* context)
 void wui_updateUIButtons(WarContext* context, bool hotKeysEnabled)
 {
     WarInput* input = &context->input;
-
     WarEntityList* buttons = we_getEntitiesOfType(context, WAR_ENTITY_TYPE_BUTTON);
+    WarEntity* hoveredButton = NULL;
+    WarEntity* capturedButton = NULL;
 
-    // store the buttons to update in this frame first
+    // NOTE: Store the buttons to update in this frame first
     // because the action of some buttons is to show other buttons
     // in their same location, and if the newly shown button is
     // after in the list, then it will update in this same frame
-    // which it shouldn't happen
+    // which shouldn't happen
     WarEntityIdSet buttonsToUpdate;
     WarEntityIdSetInit(&buttonsToUpdate, WarEntityIdSetDefaultOptions);
 
@@ -250,13 +251,42 @@ void wui_updateUIButtons(WarContext* context, bool hotKeysEnabled)
             if (ui->enabled && button->enabled && button->interactive)
             {
                 WarEntityIdSetAdd(&buttonsToUpdate, entity->id);
+
+                WarTransformComponent* transform = &entity->transform;
+                vec2 backgroundSize = vec2i(button->normalSprite.frameWidth, button->normalSprite.frameHeight);
+                rect buttonRect = rectv(transform->position, backgroundSize);
+                if (rect_containsf(buttonRect, input->pos.x, input->pos.y))
+                {
+                    hoveredButton = entity;
+                }
             }
             else
             {
                 button->hot = false;
                 button->active = false;
+
+                if (input->capturedUIButtonId == entity->id)
+                {
+                    input->capturedUIButtonId = 0;
+                }
             }
         }
+    }
+
+    if (input->capturedUIButtonId)
+    {
+        capturedButton = we_findEntity(context, input->capturedUIButtonId);
+        if (!capturedButton || !WarEntityIdSetContains(&buttonsToUpdate, capturedButton->id))
+        {
+            input->capturedUIButtonId = 0;
+            capturedButton = NULL;
+        }
+    }
+
+    if (isButtonJustPressed(input, WAR_MOUSE_LEFT) && hoveredButton)
+    {
+        input->capturedUIButtonId = hoveredButton->id;
+        capturedButton = hoveredButton;
     }
 
     for(s32 i = 0; i < buttons->count; i++)
@@ -264,10 +294,14 @@ void wui_updateUIButtons(WarContext* context, bool hotKeysEnabled)
         WarEntity* entity = buttons->items[i];
         if (entity && WarEntityIdSetContains(&buttonsToUpdate, entity->id))
         {
-            WarTransformComponent* transform = &entity->transform;
             WarButtonComponent* button = &entity->button;
+            bool isHovered = entity == hoveredButton;
+            bool isCaptured = entity == capturedButton;
 
-            if (hotKeysEnabled && wasKeyPressed(input, button->hotKey))
+            button->hot = isHovered;
+            button->active = isHovered && isCaptured && isButtonHeld(input, WAR_MOUSE_LEFT);
+
+            if (hotKeysEnabled && isKeyJustReleased(input, button->hotKey))
             {
                 if (button->clickHandler)
                 {
@@ -282,47 +316,16 @@ void wui_updateUIButtons(WarContext* context, bool hotKeysEnabled)
                 }
             }
 
-            vec2 backgroundSize = vec2i(button->normalSprite.frameWidth, button->normalSprite.frameHeight);
-            rect buttonRect = rectv(transform->position, backgroundSize);
-            bool pointerInside = rect_containsf(buttonRect, input->pos.x, input->pos.y);
-
-            if (wasButtonPressed(input, WAR_MOUSE_LEFT))
+            if (isButtonJustReleased(input, WAR_MOUSE_LEFT) && isCaptured)
             {
-                if (button->active)
+                if (isHovered && button->clickHandler)
                 {
-                    if (pointerInside && button->clickHandler)
-                    {
-                        button->clickHandler(context, entity);
-                        wa_createAudio(context, WAR_UI_CLICK, false);
-                    }
-
-                    button->active = false;
+                    button->clickHandler(context, entity);
+                    wa_createAudio(context, WAR_UI_CLICK, false);
                 }
 
-            }
-            else if (isButtonPressed(input, WAR_MOUSE_LEFT))
-            {
-                if (button->hot)
-                    button->active = true;
-            }
-            else if (pointerInside)
-            {
-                for(s32 j = 0; j < buttons->count; j++)
-                {
-                    WarEntity* otherButton = buttons->items[j];
-                    if (otherButton)
-                    {
-                        otherButton->button.hot = false;
-                        otherButton->button.active = false;
-                    }
-                }
-
-                button->hot = true;
-            }
-            else
-            {
-                button->hot = false;
                 button->active = false;
+                input->capturedUIButtonId = 0;
             }
         }
     }

--- a/todo.md
+++ b/todo.md
@@ -100,11 +100,11 @@ This was the result of deleting the entity and the engine trying to free the spr
 * [x] Selection rectangle are missing
 * [x] Progress rectangle is missing
 * [x] Cursor is too sensitive, and usually out of window area
-* [ ] Cursor should stay at the edges of the window. Should I capture the mouse from the OS!? That would allow scrolling when the cursor is at the edge and the player keep moving the mouse in the direction of that edge. Right now the OS cursor shows up when the user move the game cursor outside the window. That's no good.
+* [x] Cursor should stay at the edges of the window. Should I capture the mouse from the OS!? That would allow scrolling when the cursor is at the edge and the player keep moving the mouse in the direction of that edge. Right now the OS cursor shows up when the user move the game cursor outside the window. That's no good.
+* [x] Click in a button, drag to the map panel, it start the selection rect. This shouldn't be.
 * [ ] When the last position of a segment is occupied and there is more segments, what should be the behavior? continue to next segment from the current position? stop?
 * [ ] Check for memory leaks in the removing animations functionality.
 * [ ] Check why the changing of the global scale renders with the previous global scale after a change (only on Linux, on Windows it doesn't happen).
-* [ ] Click in a button, drag to the map panel, it start the selection rect. This shouldn't be.
 * [ ] When a unit attacks a unit that is attacking a building, the second unit should stop the attack on the building and attack the first unit.
 * [ ] If an unit is attacked when idle, the unit respond the attack.
 * [ ] Instead of Holy Sight/Dark Vision create an object, make the fog of war cells have more states like `MAP_STATE_ALWAYS_VISIBLE` and `MAP_STATE_TIMED_VISIBLE`.


### PR DESCRIPTION
This pull request refactors and modernizes the input handling system and improves memory allocation debugging support. The input state logic is now clearer and more expressive, with new macros and struct fields that distinguish between "held", "just pressed", and "just released" states for both keys and buttons. Additionally, memory allocation functions now include file and line tracking for easier debugging, and new helper functions have been added for zone-based allocations.

**Input Handling Refactor:**

* Replaced the old `pressed`/`wasPressed` input logic with a new `WarInputState` struct that tracks `held`, `justPressed`, and `justReleased` for both keys and buttons, and updated all relevant macros and usages throughout the codebase. (`src/war.h`, `src/war_fwd.h`, `src/war_cheats_panel.c`, `src/war_commands.c`, `src/war_game.c`) [[1]](diffhunk://#diff-aceb10b62c7ec67e7410ebfff301a46b42f9978890bfc8c1da18e45a6f13a329L117-R134) [[2]](diffhunk://#diff-aceb10b62c7ec67e7410ebfff301a46b42f9978890bfc8c1da18e45a6f13a329L140-R154) [[3]](diffhunk://#diff-adc866580ffb66699652af18e3bafab3cbef077297cc8933d1dc65f438139903L6-R11) [[4]](diffhunk://#diff-0eeb5a8cd3088155457497dbb9abb36829ebef702e4589bbc2a571d19b18ed17L141-R144) [[5]](diffhunk://#diff-0eeb5a8cd3088155457497dbb9abb36829ebef702e4589bbc2a571d19b18ed17L153-R153) [[6]](diffhunk://#diff-0eeb5a8cd3088155457497dbb9abb36829ebef702e4589bbc2a571d19b18ed17L162-R197) [[7]](diffhunk://#diff-0eeb5a8cd3088155457497dbb9abb36829ebef702e4589bbc2a571d19b18ed17L227-R227) [[8]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L85-R85) [[9]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L593-R593) [[10]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L628-R628) [[11]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L686-R686) [[12]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L713-R713) [[13]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L853-R853) [[14]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L894-R894) [[15]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L942-R942) [[16]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L999-R999) [[17]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L1026-R1026) [[18]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L1053-R1053) [[19]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L1075-R1075) [[20]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L1097-R1097) [[21]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L1119-R1119) [[22]](diffhunk://#diff-56ce5edca6cfcb99597170abdbb99ec7975926c52b2aa4e8e44cf69e1b7687a2L1139-R1139) [[23]](diffhunk://#diff-f2e9773a515fb9b549821c49ad4c53e5d23c1e43651cd51012466a805477d9c5R390-R418)

* Added new macros for input checks, such as `isButtonHeld`, `isButtonJustPressed`, `isButtonJustReleased`, `isKeyHeld`, `isKeyJustPressed`, and `isKeyJustReleased`, improving code readability and intent. (`src/war.h`)

* Enhanced the `WarInput` struct to support map dragging and UI button capture, and removed legacy drag fields. (`src/war.h`)

**Memory Allocation Improvements:**

* Refactored memory allocation functions to include file and line information for debugging, introduced internal helper functions for zone-based allocation, and updated the public API to use macros that automatically pass file/line info. (`src/war_alloc.c`, `src/war_alloc.h`) [[1]](diffhunk://#diff-e97a021fabb481a80780e83451ed06b0279d7628fa63e1493885d53264e73c7cR2-R3) [[2]](diffhunk://#diff-e97a021fabb481a80780e83451ed06b0279d7628fa63e1493885d53264e73c7cL28-R30) [[3]](diffhunk://#diff-e97a021fabb481a80780e83451ed06b0279d7628fa63e1493885d53264e73c7cR39-R71) [[4]](diffhunk://#diff-e97a021fabb481a80780e83451ed06b0279d7628fa63e1493885d53264e73c7cL91-R184) [[5]](diffhunk://#diff-9aa5baf5ff19096be79dcafbc76aa4ffa72ff1be7245c020d9e29fe0d1044a50L21-R32)

These changes make input handling more robust and expressive, and improve the ability to debug memory issues by tracking allocation origins.